### PR TITLE
Set shibboleth auth flags

### DIFF
--- a/compose/docker-compose.am-shib.yml
+++ b/compose/docker-compose.am-shib.yml
@@ -96,6 +96,14 @@ services:
     links:
       - "idp:idp.${DOMAIN_NAME}"
 
+  archivematica-dashboard:
+    environment:
+      ARCHIVEMATICA_DASHBOARD_SHIBBOLETH_AUTHENTICATION: "True"
+
+  archivematica-storage-service:
+    environment:
+      SS_SHIBBOLETH_AUTHENTICATION: "True"
+
 networks:
   shibnet:
     driver: "bridge"


### PR DESCRIPTION
Set environment variables for Dashboard and Storage service to switch Shibboleth authentication on when configured.

AM pull request: https://github.com/JiscRDSS/archivematica/pull/20
SS pull request: https://github.com/JiscRDSS/archivematica-storage-service/pull/6