### PR TITLE
Add AWS deployment scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ script:
   # Validate our Ansible playbooks
   - python -myamllint -f parsable *-playbook.yml
   - ansible-lint -p *-playbook.yml
+  # Validate the shell scripts for aws/machine
+  - pushd aws/machine ; find . \( -name \*.sh -or -name \*.bash \) -exec shellcheck -x -f gcc {} + ; popd
   # TODO Add additional validation/build steps here
 
 notifications:

--- a/aws/machine/.gitignore
+++ b/aws/machine/.gitignore
@@ -1,0 +1,3 @@
+.machine-credentials
+build
+logs

--- a/aws/machine/Makefile
+++ b/aws/machine/Makefile
@@ -1,0 +1,24 @@
+
+.DEFAULT_GOAL := validate
+
+validate:
+	# Run ShellCheck to validate shell scripts
+	@mkdir -p build/reports/shellcheck
+	@for f in $$(ls *.sh **/*.sh) ; do \
+		echo "Validating '$${f}' ... " ; \
+		report_file="build/reports/shellcheck/$$(echo $${f} | tr '/' '_').txt" ;\
+		docker run --rm \
+			-v $$(pwd):/scripts \
+			--workdir /scripts \
+			koalaman/shellcheck -x -f gcc \
+				$${f} | tee $${report_file} ; \
+		if [ -s $${report_file} ] ; then \
+			errors=$$(grep error: $${report_file} | wc -l) ; \
+			notes=$$(grep note: $${report_file} | wc -l) ; \
+			warnings=$$(grep warning: $${report_file} | wc -l) ; \
+			echo "Validation failed for '$${f}'. $${errors} error(s), $${warnings} warning(s), $${notes} note(s)" ; \
+			return 1 ; \
+		else \
+			echo "Validated '$${f}', all OK." ;\
+		fi ;\
+	done

--- a/aws/machine/deploy.sh
+++ b/aws/machine/deploy.sh
@@ -1,0 +1,392 @@
+#!/bin/bash
+
+#
+# Deploys an Arkivum appliance, NFS server and docker host into AWS,
+# provisioning them if necessary, and ensures that all Archivematica-related
+# containers are built and started. It also mounts the appliance and NFS server
+# into the docker host and create docker external volumes for them.
+# Also creates a public and private hosted zone and registers hosts and services
+# with them as appropriate. The public zone is intended to be referenced by an
+# existing domain, so this domain's nameserver information must be updated.
+#
+# Configuration is read from ./etc/deployment.conf, which must be created from
+# the ./etc/deployment.conf.template template file. This configuration may be
+# overriden using environment variables.
+#
+# Example usage:
+#    S3_BUCKET_PARAMS="my-data-bucket:MY-ACCESS-KEY-ID:MY-SECRET_KEY:/mnt/s3/data" \
+#        ./deploy.sh
+#
+
+# shellcheck disable=SC2034
+PROGNAME="$(basename "${BASH_SOURCE[0]}" | cut -d. -f1)"
+SCRIPT_DIR="$( cd "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" && pwd )"
+
+# Include library modules
+# shellcheck source=./lib/libs.sh
+source "${SCRIPT_DIR}/lib/libs.sh"
+
+# The AMI for the Arkivum 3 image.
+ARKIVUM_3_AMI="ami-25140241"
+
+# The AMI to use for the NFS server.
+NFS_SERVER_AMI="ami-b6daced2"
+
+# The Git repository to pull the RDSS-Archivematica source from
+RDSS_ARCHIVEMATICA_REPO="https://github.com/JiscRDSS/rdss-archivematica.git"
+
+# Do we have Shibboleth enabled?
+SHIB_ENABLED="false"
+if [ ! -z "${SHIBBOLETH_CONFIG}" ] && [ "${SHIBBOLETH_CONFIG}" != "none" ] ; then
+    SHIB_ENABLED="true"
+fi
+
+# Deployments ##################################################################
+
+deploy_arkivum()
+{
+    # Establish session
+    session_get
+    # Create security group
+    local -r sg_id="$(aws_sg_create "${ARKIVUM_INSTANCE}")"
+    # Enable SSH access
+    aws_sg_authorize_ingress "${sg_id}" "tcp" "22" "0.0.0.0/0"
+    # Import keypair
+    aws_keypair_import "${ARKIVUM_INSTANCE}" "${SSH_KEY_PATH}"
+    # Launch the instance
+    log_info "Launching Arkivum appliance '${ARKIVUM_INSTANCE}' ..."
+    local -r instance_id="$(aws_ec2_create_instance \
+            "${ARKIVUM_INSTANCE}" \
+            "arkivum" \
+            "${ARKIVUM_3_AMI}" \
+            "${ARKIVUM_INSTANCE_TYPE}" \
+            "${ARKIVUM_INSTANCE}" \
+            "${sg_id}" \
+            "${SUBNET_ID:-$(aws_vpc_get_subnet "${VPC_ID}" 0)}" \
+        )"
+    log_info "Arkivum appliance '${ARKIVUM_INSTANCE}' has id '${instance_id}'"
+    # Add a new public host entry for the instance
+    local -r pub_ip="$(aws_ec2_get_public_ip_for_instance_name "${ARKIVUM_INSTANCE}")"
+    aws_r53_add_host "${PUBLIC_HOSTED_ZONE}" "arkivum" "${pub_ip}"
+}
+
+deploy_containers() {
+    # Use docker machine to run make to create the 'external' Docker volumes
+    docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+        "cd ~/src/rdss-archivematica/compose && \
+        sudo make create-volumes \
+            AM_PIPELINE_DATA=/mnt/nfs/am-pipeline-data \
+            ARK_STORAGE_DATA=/mnt/astor \
+            JISC_TEST_DATA=/mnt/s3/jisc-rdss-test-research-data \
+            MINIO_EXPORT_DATA=/mnt/nfs/minio-export-data \
+            MYSQL_DATA=/mnt/mysql-data \
+            SS_LOCATION_DATA=/mnt/nfs/am-ss-default-location-data \
+            SS_STAGING_DATA=/mnt/nfs/am-ss-staging-data"
+    # Use docker machine to run make to deploy the containers
+    docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+        "cd ~/src/rdss-archivematica/compose ; \
+        export VOL_BASE=\$(pwd) ; \
+        export DOMAIN_NAME=${PUBLIC_HOSTED_ZONE} ; \
+        export DOMAIN_ORGANISATION=${DOMAIN_ORGANISATION} ; \
+        export NGINX_EXTERNAL_IP='0.0.0.0' ; \
+        export IDP_EXTERNAL_IP='0.0.0.0' ; \
+        export IDP_EXTERNAL_PORT=6443 ; \
+        export REGISTRY=localhost:5000/ ; \
+            make all \
+                SHIBBOLETH_CONFIG=${SHIBBOLETH_CONFIG} \
+                NEXTCLOUD_ENABLED=true"
+    # Use docker machine to copy sample data from compose dev src to minio
+    docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+        "sudo rsync -avz \
+            ~/src/rdss-archivematica/compose/dev/s3/rdss-prod-figshare-0132/ \
+            /mnt/nfs/minio-export-data/rdss-prod-figshare-0132/"
+}
+
+deploy_dockerhost()
+{
+    # Establish session
+    session_get
+    # Discover the private IP addresses for the Arkivum appliance and NFS server
+    if [ ! -z "${ARKIVUM_ENABLED}" ] ; then
+        local -r arkivum_host=$(aws_ec2_get_private_ip_for_instance_name "${ARKIVUM_INSTANCE}")
+        if [ -z "${arkivum_host}" ] ; then
+            log_fatal "Unable to detect IP address for Arkivum appliance. Ensure ${ARKIVUM_INSTANCE} exists in AWS."
+        fi
+    fi
+    local -r nfs_host=$(aws_ec2_get_private_ip_for_instance_name "${NFS_INSTANCE}")
+    if [ -z "$nfs_host" ] ; then
+        log_fatal "Unable to detect IP address for NFS server. Ensure ${NFS_INSTANCE} exists in AWS."
+    fi
+    # Check that we have parameters for connecting to the Jisc S3 bucket
+    if [ -z "${S3_BUCKET_PARAMS}" ] ; then
+        log_fatal "Required env var S3_BUCKET_PARAMS not defined."
+    fi
+    # Provision the machine, check dependencies, mount volumes, prepare images
+    # and repos, and then deploy the containers
+    docker_machine_provision && \
+        check_dockerhost_dependencies && \
+        remote_mount_nfs "${nfs_host}" && \
+        remote_mount_s3fs "${S3_BUCKET_PARAMS}" && \
+        docker_check_registry && \
+        prepare_dockerhost && \
+        deploy_containers
+    if [ ! -z "${ARKIVUM_ENABLED}" ] ; then
+        # Add the Arkivum mount to the docker host
+        remote_mount_arkivum "${arkivum_host}"
+    fi
+    # Get the ports for each exposed service
+    local am_dash_port
+    local am_ss_port
+    local nextcloud_port
+    local shib_idp_port
+    am_dash_port="$(docker_get_service_port 'nginx' 80)"
+    am_ss_port="$(docker_get_service_port 'nginx' 8000)"
+    nextcloud_port="$(docker_get_service_port 'nextcloud' 8888)"
+    if [ "${SHIB_ENABLED}" == "true" ] ; then
+        am_dash_port="$(docker_get_service_port 'nginx' 443)"
+        am_ss_port="$(docker_get_service_port 'nginx' 8443)"
+        nextcloud_port="$(docker_get_service_port 'nextcloud' 8888)"
+        shib_idp_port="$(docker_get_service_port 'idp' 4443)"
+    fi
+    # Add ingress rule for each of the exposed services
+    local -r sg_id="$(aws_sg_get "${DOCKERHOST_INSTANCE}")"
+    aws_sg_authorize_ingress "${sg_id}" "tcp" "${am_dash_port}" "0.0.0.0/0"
+    aws_sg_authorize_ingress "${sg_id}" "tcp" "${am_ss_port}" "0.0.0.0/0"
+    aws_sg_authorize_ingress "${sg_id}" "tcp" "${nextcloud_port}" "0.0.0.0/0"
+    if [ "${SHIB_ENABLED}" == "true" ] ; then
+        aws_sg_authorize_ingress "${sg_id}" "tcp" "${shib_idp_port}" "0.0.0.0/0"
+    fi
+    # Add a private hosts entry for the docker host
+    local -r priv_ip="$(aws_ec2_get_private_ip_for_instance_name "${DOCKERHOST_INSTANCE}")"
+    aws_r53_add_host "${PRIVATE_HOSTED_ZONE}" "dockerhost" "${priv_ip}"
+    # Add alias and services for Archivematica
+    aws_r53_add_host_alias "${PRIVATE_HOSTED_ZONE}" \
+        "archivematica" "dockerhost.${PRIVATE_HOSTED_ZONE}"
+    aws_r53_add_service "${PRIVATE_HOSTED_ZONE}" \
+        "am_dashboard" "${am_dash_port}" "tcp" "archivematica.${PRIVATE_HOSTED_ZONE}"
+    aws_r53_add_service "${PRIVATE_HOSTED_ZONE}" \
+        "am_storage_service" "${am_ss_port}" "tcp" "archivematica.${PRIVATE_HOSTED_ZONE}"
+    # Add alias and service for NextCloud, if required
+    aws_r53_add_host_alias "${PRIVATE_HOSTED_ZONE}" \
+        "nextcloud" "dockerhost.${PRIVATE_HOSTED_ZONE}"
+    aws_r53_add_service "${PRIVATE_HOSTED_ZONE}" \
+        "nextcloud" "${nextcloud_port}" "tcp" "nextcloud.${PRIVATE_HOSTED_ZONE}"
+    # Add alias and services for Shibboleth, if required
+    if [ "${SHIB_ENABLED}" == "true" ] ; then
+        aws_r53_add_host_alias "${PRIVATE_HOSTED_ZONE}" \
+            "idp" "dockerhost.${PRIVATE_HOSTED_ZONE}"
+        aws_r53_add_service "${PRIVATE_HOSTED_ZONE}" \
+            "idp" "${shib_idp_port}" "tcp" "idp.${PRIVATE_HOSTED_ZONE}"
+    fi
+    # Add public service entries for each of the externally accessible services
+    local -r pub_ip="$(aws_ec2_get_public_ip_for_instance_name "${DOCKERHOST_INSTANCE}")"
+    aws_r53_add_host "${PUBLIC_HOSTED_ZONE}" "archivematica" "${pub_ip}"
+    aws_r53_add_host "${PUBLIC_HOSTED_ZONE}" "nextcloud" "${pub_ip}"
+    if [ "${SHIB_ENABLED}" == "true" ] ; then
+        aws_r53_add_host "${PUBLIC_HOSTED_ZONE}" "idp" "${pub_ip}"
+    fi
+}
+
+deploy_hosted_zones()
+{
+    # Establish session
+    session_get
+    # Deploy the private hosted zone
+    aws_r53_create_private_zone "${VPC_ID}" "${PRIVATE_HOSTED_ZONE}"
+    # Deploy the public hosted zone
+    aws_r53_create_public_zone "${PUBLIC_HOSTED_ZONE}"
+}
+
+deploy_nfs_server()
+{
+    # Establish session
+    session_get
+    # Create security group
+    local -r sg_id="$(aws_sg_create "${NFS_INSTANCE}")"
+    # Enable SSH access
+    aws_sg_authorize_ingress "${sg_id}" "tcp" "22" "0.0.0.0/0"
+    # Enable global access from other instances in the same VPC
+    aws_sg_authorize_ingress "${sg_id}" "tcp" "0-65535" \
+        "$(aws_vpc_get_cidr "${VPC_ID}")"
+    # Import keypair
+    aws_keypair_import "${NFS_INSTANCE}" "${SSH_KEY_PATH}"
+    # Launch the instance
+    log_info "Launching NFS server '${NFS_INSTANCE}' ..."
+    local -r instance_id="$(aws_ec2_create_instance \
+            "${NFS_INSTANCE}" \
+            "nfs" \
+            "${NFS_SERVER_AMI}" \
+            "${NFS_INSTANCE_TYPE}" \
+            "${NFS_INSTANCE}" \
+            "${sg_id}" \
+            "${SUBNET_ID:-$(aws_vpc_get_subnet "${VPC_ID}" 0)}" \
+            "file://${NFS_USERDATA:-etc/userdata/nfs}" \
+        )"
+    log_info "NFS server '${NFS_INSTANCE}' has id '${instance_id}'"
+    local -r volume_name="${NFS_INSTANCE}-data"
+    local volume_id
+    volume_id="$(aws_ec2_get_id_for_volume_name "${volume_name}")"
+    if [ "${volume_id}" == "" ] ; then
+        # Create a new EBS volume for data storage
+        log_info "Creating EBS volume '${volume_name}' ..."
+        volume_id=$(aws ec2 create-volume \
+            --size "${NFS_STORAGE_SIZE}" \
+            --region "${AWS_REGION}" \
+            --availability-zone "${AWS_REGION}a" \
+            --volume-type "${NFS_STORAGE_VOLUME_TYPE}" \
+            --query 'VolumeId' \
+            --output text)
+        # Tag the created resource to allow us to identify it
+        aws_ec2_tag_resource "${volume_id}" \
+            "${volume_name}" "${PROJECT_ID}" "${ENVIRONMENT}"
+    fi
+    log_info "NFS server volume '${volume_name}' has id '${volume_id}'"
+    # Check if the volume is attached
+    local -r vol_attached_ids="$(aws_ec2_get_volume_attached_instance_ids "${volume_id}")"
+    if [ "$(echo "${vol_attached_ids}" | grep "${instance_id}")" == "" ] ; then
+        # Wait for the instance to be "running"
+        local instance_state
+        while [ "$instance_state" != "available" ] ; do
+            instance_state="$(aws_ec2_get_instance_state "${instance_id}")"
+            case $instance_state in
+                running)
+                    log_info "Instance is now running."
+                    break
+                    ;;
+                *)
+                    log_info "Instance state is '${instance_state}', waiting..."
+                    sleep 2
+                    ;;
+            esac
+        done
+        # Wait for the volume to become "available"
+        local volume_state=""
+        while [ "$volume_state" != "available" ] ; do
+            volume_state="$(aws_ec2_get_volume_state "${volume_id}")"
+            case $volume_state in
+                available)
+                    log_info "Volume is now available."
+                    break
+                    ;;
+                *)
+                    log_info "Volume state is '${volume_state}', waiting..."
+                    sleep 2
+                    ;;
+            esac
+        done
+        # Attach the EBS volume to NFS server instance
+        log_info "Attaching volume '${volume_name}' to '${NFS_INSTANCE}' ..."
+        aws ec2 attach-volume \
+            --device '/dev/xvdf' \
+            --instance-id "${instance_id}" \
+            --volume-id "${volume_id}"
+        log_info "Attached volume '${volume_name}' to '${NFS_INSTANCE}'."
+    else
+        log_info "Volume '${volume_name}' already attached to instance '${NFS_INSTANCE}'."
+    fi
+}
+
+# Clones the rdss-archivematica repo and uses Ansible to build and deploy the
+# container images to the local registry on the remote host, ready for use by
+# the docker-compose instantiation process
+prepare_dockerhost()
+{
+    # Clone compose repo and run build playbooks in the remote Docker host
+    # shellcheck disable=SC2088
+    local -r clone_dir="~/src/rdss-archivematica"
+    log_info "Cloning ${clone_dir} and publishing images ..."
+    docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+        "sudo rm -Rf ${clone_dir} && mkdir -p ${clone_dir} && \
+            git clone --branch '${RDSSARK_VERSION}' \
+                ${RDSS_ARCHIVEMATICA_REPO} ${clone_dir} && \
+            ansible-playbook  \
+                --extra-vars='registry=localhost:5000/' \
+                ${clone_dir}/publish-images-playbook.yml \
+                ${clone_dir}/publish-qa-images-playbook.yml"
+}
+
+# Entrypoint ###################################################################
+
+main()
+{
+    log_info "RDSSARK Deployment Script starting..."
+    log_info "The following branch or version will be used: ${RDSSARK_VERSION}"
+    log_info "The following AWS parameters will be used:"
+    log_info "  MFA enabled: ${MFA_AUTH_ENABLED}"
+    log_info "  Region     : ${AWS_REGION}"
+    log_info "  VPC Id     : ${VPC_ID}"
+    log_info "  Subnet Id  : ${SUBNET_ID:-auto}"
+    log_info "The following hosted zones will be deployed:"
+    log_info "  Private: ${PRIVATE_HOSTED_ZONE}"
+    log_info "  Public : ${PUBLIC_HOSTED_ZONE}"
+    log_info "The following instances will be deployed:"
+    if [ ! -z "${ARKIVUM_ENABLED}" ] ; then
+        log_info "  Arkivum appliance: ${ARKIVUM_INSTANCE}"
+    fi
+    log_info "  NFS server:        ${NFS_INSTANCE}"
+    log_info "  Docker host:       ${DOCKERHOST_INSTANCE}"
+    log_info "The following application security parameters will be used:"
+    log_info "  Deployment Domain: ${DOMAIN_ORGANISATION}"
+    log_info "  Shibboleth Config: ${SHIBBOLETH_CONFIG}"
+    log_info "The following services will be deployed:"
+    local am_dash_url
+    local am_ss_url
+    am_dash_url="http://archivematica.${PUBLIC_HOSTED_ZONE}:<dynamic-port>/"
+    am_ss_url="http://archivematica.${PUBLIC_HOSTED_ZONE}:<dynamic-port>/"
+    if [ "${SHIB_ENABLED}" == "true" ] ; then
+        # With Shibboleth enabled the ports are fixed and HTTPS is used
+        am_dash_url="https://archivematica.${PUBLIC_HOSTED_ZONE}/"
+        am_ss_url="https://archivematica.${PUBLIC_HOSTED_ZONE}:8443/"
+    fi
+    log_info "  Archivematica Dashboard:       ${am_dash_url}"
+    log_info "  Archivematica Storage Service: ${am_ss_url}"
+    if [ ! -z "${ARKIVUM_ENABLED}" ] ; then
+        log_info "  Arkivum appliance:             https://arkivum.${PUBLIC_HOSTED_ZONE}:8443/"
+    fi
+    log_info "  NextCloud:                     http://nextcloud.${PUBLIC_HOSTED_ZONE}:8888/"
+    log_info "  RDSS Archivematica MsgCreator: ${am_dash_url}msgcreator"
+    log_note "If this looks incorrect, abort now using CTRL+C ..."
+    sleep 10
+    log_info ">>>>>> DEPLOYING >>>>>"
+    # Deploy the hosted zones
+    deploy_hosted_zones
+    if [ ! -z "${ARKIVUM_ENABLED}" ] ; then
+        # Deploy the Arkivum appliance
+        deploy_arkivum
+    fi
+    # Deploy the NFS server used as shared storage
+    deploy_nfs_server
+    # Deploy the docker host that will run Archivematica and NextCloud
+    deploy_dockerhost
+    log_info "<<<<<< DEPLOYMENT COMPLETE <<<<<"
+    log_info "Deployed instances:"
+    if [ ! -z "${ARKIVUM_ENABLED}" ] ; then
+        local -r arkivum_ip="$(aws_ec2_get_public_ip_for_instance_name "${ARKIVUM_INSTANCE}")"
+        log_info "  Arkivum appliance: ${arkivum_ip} / ${ARKIVUM_INSTANCE}"
+    fi
+    local -r dockerhost_ip="$(aws_ec2_get_public_ip_for_instance_name "${DOCKERHOST_INSTANCE}")"
+    log_info "  Docker host      : ${dockerhost_ip} / ${DOCKERHOST_INSTANCE}"
+    local -r nfs_ip="$(aws_ec2_get_public_ip_for_instance_name "${NFS_INSTANCE}")"
+    log_info "  NFS server       : ${nfs_ip} / ${NFS_INSTANCE}"
+    log_info "Deployed services:"
+    if [ "${SHIB_ENABLED}" != "true" ] ; then
+        # With Shibboleth disabled the ports are dynamic and HTTP is used
+        local -r am_dash_port="$(docker_get_service_port 'nginx' 80)"
+        local -r am_ss_port="$(docker_get_service_port 'nginx' 8000)"
+        am_dash_url="http://archivematica.${PUBLIC_HOSTED_ZONE}:${am_dash_port}/"
+        am_ss_url="http://archivematica.${PUBLIC_HOSTED_ZONE}:${am_ss_port}/"
+    fi
+    log_info "  Archivematica Dashboard:       ${am_dash_url}"
+    log_info "  Archivematica Storage Service: ${am_ss_url}"
+    if [ ! -z "${ARKIVUM_ENABLED}" ] ; then
+        log_info "  Arkivum appliance:             https://arkivum.${PUBLIC_HOSTED_ZONE}:8443/"
+    fi
+    log_info "  NextCloud:                     http://nextcloud.${PUBLIC_HOSTED_ZONE}:8888/"
+    log_info "  RDSS Archivematica MsgCreator: ${am_dash_url}msgcreator"
+    local -r public_ns="$(aws_r53_get_zone_ns "${PUBLIC_HOSTED_ZONE}")"
+    log_info "The following NS records must be added to DNS for ${PUBLIC_DOMAIN_NAME}:"
+    log_info "  ${public_ns}"
+    log_info "Done."
+}
+
+main "$@"

--- a/aws/machine/etc/.gitignore
+++ b/aws/machine/etc/.gitignore
@@ -1,0 +1,1 @@
+deployment.conf

--- a/aws/machine/etc/deployment.conf.template
+++ b/aws/machine/etc/deployment.conf.template
@@ -1,0 +1,108 @@
+#
+# Machine deployment configuration
+#
+
+# Amazon Web Services ##########################################################
+
+# Whether or not to use MFA authentication
+MFA_AUTH_ENABLED=${MFA_AUTH_ENABLED:-true}
+
+# The ARN for the MFA device you wish to use to authenticate.
+MFA_DEVICE_ID=${MFA_DEVICE_ID:-"<your-mfa-device-arn>"}
+
+# The region to deploy to. Defaults to eu-west-2 (London).
+AWS_REGION=${AWS_REGION:-'eu-west-2'}
+
+# The ID of the existing Virtual Private Cloud to provision EC2 instances into.
+VPC_ID=${VPC_ID:-"<your-vpc-id>"}
+
+# The ID of the existing subnet to deploy EC2 instance into. If not specified
+# then the first subnet of the VPC will be used.
+SUBNET_ID=${SUBNET_ID}
+
+# Deployment ###################################################################
+
+# The SSH key to use to secure the deployed instances.
+SSH_KEY_PATH=${SSH_KEY_PATH:-~/.ssh/id_rsa_MyAwsKey}
+
+# The project id this deployment is for. Can be anything, but should be
+# numerical to match what Jisc use.
+PROJECT_ID=${PROJECT_ID:-"0000"}
+
+# Environment this deployment is for. Should be one of 'dev', 'uat', or 'prod'.
+ENVIRONMENT=${ENVIRONMENT:-"dev"}
+
+# The public domain name to use for for deployed services. This is managed by a
+# public Route53 hosted zone, so must be under your control. It is also used to
+# generate SSL certificates. Defaults to 'example.ac.uk'.
+PUBLIC_DOMAIN_NAME=${PUBLIC_DOMAIN_NAME:-"example.ac.uk"}
+
+# Private Route53 hosted zone. This is used to address services internally within the VPC.
+PRIVATE_HOSTED_ZONE=${PRIVATE_HOSTED_ZONE:-"${PROJECT_ID}-${ENVIRONMENT}"}
+
+# Public Route53 hosted zone. This is used to address services externally from the internet.
+# The top-level domain must exist and reference Route53 for its nameservers.
+PUBLIC_HOSTED_ZONE=${PUBLIC_HOSTED_ZONE:-"${PRIVATE_HOSTED_ZONE}.${PUBLIC_DOMAIN_NAME}"}
+
+# The version or branch of RDSSARK to deploy. Default is 'master'.
+RDSSARK_VERSION=${RDSSARK_VERSION:-"master"}
+
+# Arkivum appliance ############################################################
+
+# Whether or not to include an Arkivum appliance in this deployment. If set to a
+# non-empty value (e.g. `true`) then an appliance will be included, otherwise
+# there will be no appliance. Defaults to "", so no appliance is included.
+ARKIVUM_ENABLED=${ARKIVUM_ENABLED:-""}
+
+# Name of the EC2 instance to run this deployment's Arkivum appliance. This
+# will be created automatically if it does not already exist.
+ARKIVUM_INSTANCE=${ARKIVUM_INSTANCE:-"${PROJECT_ID}-${ENVIRONMENT}-arkivum"}
+
+# The EC2 instance type to use for this deployment's Arkivum appliance.
+ARKIVUM_INSTANCE_TYPE=${ARKIVUM_INSTANCE_TYPE:-"t2.nano"}
+
+# Docker host ##################################################################
+
+# Name of the EC2 instance to run this deployment's Docker host. This will be
+# created automatically if it does not already exist.
+DOCKERHOST_INSTANCE=${DOCKERHOST_INSTANCE:-"${PROJECT_ID}-${ENVIRONMENT}-dockerhost"}
+
+# The EC2 instance type to use for this deployment's Docker host. Must be at
+# least 't2.medium' otherwise build will fail.
+DOCKERHOST_INSTANCE_TYPE=${DOCKERHOST_INSTANCE_TYPE:-"t2.medium"}
+
+# The size of the root partition for this deployment's Docker host, in
+# gigabytes. Default is 16, which is the minimum viable for running our Docker
+# containers.
+DOCKERHOST_ROOT_SIZE=${DOCKERHOST_ROOT_SIZE:-16}
+
+# NextCloud ####################################################################
+
+# Parameters for the S3 bucket to mount as part of the NextCloud service
+S3_BUCKET_PARAMS=${S3_BUCKET_PARAMS:-""}
+
+# NFS server ###################################################################
+
+# Name of the EC2 instance that is running this deployment's NFS server. This
+# will be created automatically if it does not already exist.
+NFS_INSTANCE=${NFS_INSTANCE:-"${PROJECT_ID}-${ENVIRONMENT}-nfs"}
+
+# The EC2 instance type to use for this deployment's NFS server.
+NFS_INSTANCE_TYPE=${NFS_INSTANCE_TYPE:-"t2.nano"}
+
+# Size of EBS volume to provision for use by the NFS server for storage, in GB.
+NFS_STORAGE_SIZE=${NFS_STORAGE_SIZE:-10}
+
+# Volume type of the EBS volume to provision for use by the NFS server for
+# storage. Defaults to 'gp2', but should be changed to 'sc1' or 'st1' if the
+# size is increased to 500GB or more.
+NFS_STORAGE_VOLUME_TYPE=${NFS_STORAGE_VOLUME_TYPE:-"gp2"}
+
+# Application Security #########################################################
+
+# The organisation that 'owns' this domain. Used for SSL certificate information
+# but also Shibboleth configuration. Default is "Example University".
+DOMAIN_ORGANISATION=${DOMAIN_ORGANISATION:-"Example University"}
+
+# Which Shibboleth config to use, if any. Default is "archivematica".
+SHIBBOLETH_CONFIG=${SHIBBOLETH_CONFIG:-"archivematica"}

--- a/aws/machine/etc/userdata/nfs
+++ b/aws/machine/etc/userdata/nfs
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#Install xfsprogs
+yum -y install xfsprogs
+
+# create fs if needed
+if file -s "/dev/xvdf" | grep "/dev/xvdf: data"; then
+echo "creating fs for nfs data volume"
+mkfs.xfs "/dev/xvdf"
+fi
+
+# mount it
+mkdir "/mnt/nfs"
+echo "/dev/xvdf       /mnt/nfs   xfs    defaults,nofail  0 2" >> /etc/fstab
+echo "mounting nfs data disk"
+mount -a
+
+# start NFS service
+echo "/mnt/nfs *(rw,sync,no_root_squash,no_subtree_check)" > /etc/exports
+chmod 777 /mnt/nfs
+
+service nfs restart

--- a/aws/machine/lib/lib-aws.sh
+++ b/aws/machine/lib/lib-aws.sh
@@ -1,0 +1,915 @@
+#!/bin/bash
+
+#
+# Functions related to AWS based services and resource management.
+#
+
+# Only load this library once
+if [ -z "${_LIB_AWS_SH}" ] ; then
+
+LIB_DIR="$( cd "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" && pwd )"
+
+# Include dependencies
+# shellcheck source=./lib/lib-config.sh
+source "${LIB_DIR}/lib-config.sh"
+
+# Amazon Web Services ##########################################################
+
+# Attempts normal authentication with AWS, without Multi-Factor Authentication.
+aws_auth()
+{
+    if [ -s "${MACHINE_CREDENTIALS_FILE}" ] ; then
+        return
+    fi
+    log_info "No AWS session, authenticating..."
+    # Create STS session using aws cli
+    aws sts get-session-token --output text > "${MACHINE_CREDENTIALS_FILE}"
+    # Make it so that no one else can read the credentials file
+    chmod u=rw,o= "${MACHINE_CREDENTIALS_FILE}"
+    log_info "Authenticated with AWS"
+}
+
+# Attempts full authentication with AWS, including Multi-Factor Authentication.
+aws_auth_mfa()
+{
+    if [ -s "${MACHINE_CREDENTIALS_FILE}" ] ; then
+        return
+    fi
+    log_info "No AWS session, requesting MFA authentication credentials..."
+    # Read the MFA code from the user input
+    local mfa_token
+    read -r -p "MFA Code: " mfa_token
+    # Create STS session using aws cli
+    aws sts get-session-token \
+       --output text \
+       --serial-number "${MFA_DEVICE_ID}" \
+       --token-code "${mfa_token}" > "${MACHINE_CREDENTIALS_FILE}"
+    # Make it so that no one else can read the credentials file
+    chmod u=rw,o= "${MACHINE_CREDENTIALS_FILE}"
+    log_info "Authenticated with AWS"
+}
+
+aws_ec2_create_instance()
+{
+    local -r name="$1"
+    local -r hostname="$2"
+    local -r image_id="$3"
+    local -r instance_type="$4"
+    local -r key_name="$5"
+    local -r sg_id="$6"
+    local -r subnet_id="$7"
+    local -r user_data="$8"
+    # Establish session
+    session_get
+    # Get existing instance id, if any
+    local instance_id
+    instance_id="$(aws_ec2_get_id_for_instance_name "${name}")"
+    # If we got an instance id (or ids) then iterate through them to confirm
+    # they are or it is in a running state (multiple ids can happen if instances
+    # are stopped/started in quick succession or if a AWS limit is hit).
+    # shellcheck disable=SC2001
+    for i_id in $(echo "${instance_id}" | sed "s/$/ /g") ; do
+        local i_state
+        i_state="$(aws_ec2_get_instance_state "${i_id}")"
+        if [ "${i_state}" != "running" ] ; then
+            # Remove the instance from the instance ids list
+            log_debug "Instance ${i_id} is in state ${i_state}, ignoring."
+            instance_id="$(echo "${instance_id}" | sed "s/${i_id}//")"
+        fi
+    done
+    instance_id="${instance_id// //}"
+    if [ "${instance_id}" == "" ] ; then
+        # Launch the instance
+        log_info "Launching instance '${name}' ..."
+        if [ "${user_data}" == "" ] ; then
+            # Create the instance without any user data
+            instance_id="$(aws ec2 run-instances \
+                --image-id "${image_id}" \
+                --count 1 \
+                --instance-type "${instance_type}" \
+                --key-name "${key_name}" \
+                --security-group-ids "${sg_id}" \
+                --subnet-id "${subnet_id}" \
+                --associate-public-ip-address \
+                --query 'Instances[0].InstanceId' \
+                --output text)"
+        else
+            # Create the instance with the specified user data
+            instance_id="$(aws ec2 run-instances \
+                --image-id "${image_id}" \
+                --count 1 \
+                --instance-type "${instance_type}" \
+                --key-name "${key_name}" \
+                --security-group-ids "${sg_id}" \
+                --subnet-id "${subnet_id}" \
+                --user-data "${user_data}" \
+                --associate-public-ip-address \
+                --query 'Instances[0].InstanceId' \
+                --output text)"
+        fi
+        if [ "${instance_id}" == "" ] ; then
+            log_fatal "Failed to create instance for '${name}', aborting."
+        fi
+        # Tag the created instance and security group to allow us to identify them
+        aws_ec2_tag_resource "${instance_id}" \
+            "${name}" "${PROJECT_ID}" "${ENVIRONMENT}"
+        aws_ec2_tag_resource "${sg_id}" \
+            "${name}" "${PROJECT_ID}" "${ENVIRONMENT}"
+        # Wait for the instance to initialize
+        local instance_state
+        instance_state="$(aws_ec2_get_instance_state "${instance_id}")"
+        while [ "${instance_state}" != "running" ] ; do
+            if [ "${instance_state}" == "terminated" ] || \
+                [ "${instance_state}" == "terminating" ] || \
+                [ "${instance_state}" == "shutting-down" ] ; then
+                    # This instance is on the way down, abort
+                    log_fatal "Instance '${instance_id}' is no longer running (${instance_state}), aborting."
+            fi
+            log_info "Waiting for instance '${instance_id}' to start (${instance_state})"
+            sleep 10
+            instance_state="$(aws_ec2_get_instance_state "${instance_id}")"
+        done
+        # Tag the volume(s) created by EC2 for the instance
+            local -r vol_ids="$(aws_ec2_get_instance_attached_volumes "${instance_id}")"
+            local vol_index
+            vol_index=0
+            for v_id in $vol_ids ; do
+                aws_ec2_tag_resource "${v_id}" \
+                    "${name}-disk-${vol_index}" "${PROJECT_ID}" "${ENVIRONMENT}"
+                vol_index="$((vol_index + 1))"
+            done
+        # Add a new private host entry for the instance
+        local -r priv_ip="$(aws_ec2_get_private_ip_for_instance_name "${name}")"
+        aws_r53_add_host "${PRIVATE_HOSTED_ZONE}" "${hostname}" "${priv_ip}"
+    fi
+    # Output the instance id for callers to pick up
+    echo "${instance_id}"
+}
+
+# Gets the instance id for the given EC2 instance name. If the optional
+# required state parameter is given then only instances in that state will be
+# considered.
+aws_ec2_get_id_for_instance_name()
+{
+    local instance_name="$1"
+    local required_state="$2"
+    # Establish session
+    session_get
+    # Get instance id
+    log_debug "Getting instance id for '${instance_name}'..."
+    # Use AWS CLI to describe the instance and get its id
+    local instance_id=""
+    if [ "${required_state}" == "" ] ; then
+        instance_id="$(aws ec2 describe-instances \
+            --filters \
+                "Name=tag:Name,Values=${instance_name}*" \
+            --query "Reservations[*].Instances[*].[InstanceId]" \
+            --output=text)"
+    else
+        instance_id="$(aws ec2 describe-instances \
+            --filters \
+                "Name=tag:Name,Values=${instance_name}*" \
+                "Name=instance-state-name,Values=${required_state}" \
+            --query "Reservations[*].Instances[*].[InstanceId]" \
+            --output=text)"
+    fi
+    if [ -z "${instance_id}" ] || [ "${instance_id}" == "None" ] ; then
+        log_debug "Warning: No id found for instance '${instance_name}'."
+    else
+        log_debug "Got id '${instance_id}' for instance '${instance_name}'."
+        echo "${instance_id}"
+    fi
+}
+
+# Gets the attached volume ids for the given instance id.
+aws_ec2_get_instance_attached_volumes()
+{
+    local -r instance_id="$1"
+    # Establish session
+    session_get
+    # Get instance attached volumes
+    log_debug "Getting attached volumes for '${instance_id}'..."
+    # Use AWS CLI to describe the volumes attached to the given instance
+    local -r attached_volumes="$(aws ec2 describe-volumes \
+        --filter "Name=attachment.instance-id,Values=${instance_id}" \
+        --query "Volumes[*].VolumeId" --output text)"
+    echo "${attached_volumes}"
+}
+
+# Gets the current instance state for the given instance id.
+aws_ec2_get_instance_state()
+{
+    local -r instance_id="$1"
+    # Establish session
+    session_get
+    # Get instance state
+    log_debug "Getting instance state for '${instance_id}'..."
+    # Use AWS CLI to describe the instance and get its state
+    local -r instance_state="$(aws ec2 describe-instances \
+        --instance-ids "${instance_id}" \
+        --query "Reservations[*].Instances[*].State.Name" \
+        --output text)"
+    echo "${instance_state}"
+}
+
+# Gets the private IP address for the given EC2 instance name. Only running
+# instances will be considered, instances in other states will be ignored.
+aws_ec2_get_private_ip_for_instance_name()
+{
+    local instance_name="$1"
+    # Establish session
+    session_get
+    # Get the private IP for the instance
+    log_debug "Getting private IP for '${instance_name}'..."
+    # Use AWS CLI to describe the instance and get its private IP address
+    local -r private_ip=$(aws ec2 describe-instances \
+        --filters \
+            "Name=tag:Name,Values=${instance_name}*" \
+            "Name=instance-state-name,Values=running" \
+        --query "Reservations[*].Instances[*].[PrivateIpAddress]" \
+        --output=text)
+    if [ -z "${private_ip}" ] || [ "${private_ip}" == "None" ] ; then
+        log_warn "No private IP found for instance '${instance_name}'."
+    else
+        log_debug "Got private IP '${private_ip}' for instance '${instance_name}'."
+        echo "${private_ip}"
+    fi
+}
+
+# Gets the public IP address for the given EC2 instance name. Only running
+# instances will be considered, instances in other states will be ignored.
+aws_ec2_get_public_ip_for_instance_name()
+{
+    local instance_name="$1"
+    # Establish session
+    session_get
+    # Get the public IP for the instance
+    log_debug "Getting public IP for '${instance_name}'..."
+    # Use AWS CLI to describe the instance and get its public IP address
+    local -r public_ip=$(aws ec2 describe-instances \
+        --filters \
+            "Name=tag:Name,Values=${instance_name}*" \
+            "Name=instance-state-name,Values=running" \
+        --query "Reservations[*].Instances[*].[PublicIpAddress]" \
+        --output=text)
+    if [ -z "${public_ip}" ] || [ "${public_ip}" == "None" ] ; then
+        log_warn "No public IP found for instance '${instance_name}'."
+    else
+        log_debug "Got public IP '${public_ip}' for instance '${instance_name}'."
+        echo "${public_ip}"
+    fi
+}
+
+# Gets the volume id for the given EC2 volume name.
+aws_ec2_get_id_for_volume_name()
+{
+    local volume_name="$1"
+    # Establish session
+    session_get
+    # Get the volume id
+    log_debug "Getting volume id for '${volume_name}'..."
+    # Use AWS CLI to describe the volume and get its id
+    local -r volume_id=$(aws ec2 describe-volumes \
+        --filters "Name=tag:Name,Values=${volume_name}*" \
+        --query "Volumes[*].VolumeId" \
+        --output=text)
+    if [ -z "${volume_id}" ] || [ "${volume_id}" == "None" ] ; then
+        log_warn "No id found for volume '${volume_name}'."
+    else
+        log_debug "Got id '${volume_id}' for volume '${volume_name}'."
+        echo "${volume_id}"
+    fi
+}
+
+# Gets the instance id(s) that the volume with the given id is attached to.
+aws_ec2_get_volume_attached_instance_ids()
+{
+    local volume_id="$1"
+    # Establish session
+    session_get
+    # Get attached instances for the volume
+    log_debug "Getting volume attachments for '${volume_id}'..."
+    # Use AWS CLI to describe the volume and get its attached instance ids
+    local -r instance_ids="$(aws ec2 describe-volumes \
+        --volume-id "${volume_id}" \
+        --query "Volumes[0].Attachments[*].InstanceId" \
+        --output text)"
+    echo "${instance_ids}"
+}
+
+# Gets the current volume state for the given volume id.
+aws_ec2_get_volume_state()
+{
+    local volume_id="$1"
+    # Establish session
+    session_get
+    # Get the state of the volume
+    log_info "Getting volume state for '${volume_id}'..."
+    # Use AWS CLI to describe the volume and get its state
+    local -r volume_state="$(aws ec2 describe-volumes \
+        --volume-id "${volume_id}" \
+        --query "Volumes[0].State" \
+        --output text)"
+    echo "${volume_state}"
+}
+
+# Tags the given resource with the given name, project id and environment.
+aws_ec2_tag_resource()
+{
+    local -r resource_id="$1"
+    local -r tag_name="$2"
+    local -r tag_proj="$3"
+    local -r tag_env="$4"
+    # Establish session
+    session_get
+	# Tag the resource with the given tags
+	log_debug "Tagging '${resource_id}': Name='${tag_name}', ProjectId='${tag_proj}', Environment='${tag_env}'..."
+	aws ec2 create-tags \
+		--resources "${resource_id}" \
+		--tags \
+		  "Key=Name,Value=${tag_name}" \
+		  "Key=ProjectId,Value=${tag_proj}" \
+		  "Key=Environment,Value=${tag_env}"
+	log_info "Tagged '${resource_id}': Name='${tag_name}', ProjectId='${tag_proj}', Environment='${tag_env}'."
+}
+
+# Terminates the instance with the given id or ids. If multiple instance ids are
+# given then all instances will be terminated.
+aws_ec2_terminate_instance()
+{
+    local -r instance_id="$1"
+    # Establish session
+    session_get
+    # Terminate instance
+    log_info "Terminating instance '${instance_id}'..."
+    aws ec2 terminate-instances --instance-ids "${instance_id}"
+    # If we got an instance id (or ids) then iterate through them to confirm
+    # they are or it is in a terminated state (multiple ids can happen if instances
+    # are stopped/started in quick succession or if a AWS limit is hit).
+    # shellcheck disable=SC2001
+    for i_id in $(echo "${instance_id}" | sed "s/$/ /g") ; do
+        local i_state
+        i_state="$(aws_ec2_get_instance_state "${i_id}")"
+        # Wait for the instance to shut down
+        while [ "${i_state}" != "terminated" ] ; do
+            log_info "Waiting for instance '${i_id}' to shut down (${i_state})"
+            sleep 8
+            i_state="$(aws_ec2_get_instance_state "${i_id}")"
+        done
+        log_info "Terminated instance '${instance_id}'."
+    done
+}
+
+# Determines if a keypair with the given name exists. Returns true if it does,
+# or false otherwise.
+aws_keypair_exists()
+{
+    local -r keypair_name="$1"
+    [ "$(aws ec2 describe-key-pairs --filter \
+            "Name=key-name,Values=${keypair_name}" \
+            --query "KeyPairs[*].KeyName" --output text)" != "" ]
+    return $?
+}
+
+# Imports the given source key with the given key name. If a key with the same
+# name already exists then it will be left as-is and not be replaced.
+aws_keypair_import()
+{
+    local -r keypair_name="$1"
+    local -r keypair_srcpath="$2"
+    # Establish session
+    session_get
+    # Read the public key data
+    local -r pub_key="$(openssl rsa -in "${keypair_srcpath}" \
+        -pubout 2>/dev/null | tail -n +2 | head -n -1 | tr -d "\\n")"
+    if ! aws_keypair_exists "${keypair_name}" ; then
+        log_info "Importing keypair '${keypair_srcpath}' as '${keypair_name}' ..."
+        aws ec2 import-key-pair \
+            --key-name "${keypair_name}" \
+            --public-key-material "${pub_key}"
+        log_info "Imported keypair '${keypair_name}'."
+    fi
+}
+
+# Removes the keypair with the given name, if it exists.
+aws_keypair_remove()
+{
+    local -r keypair_name="$1"
+    # Establish session
+    session_get
+    # Remove the keypair
+    if aws_keypair_exists "${keypair_name}" ; then
+        log_info "Deleting keypair '${keypair_name}' ... "
+        aws ec2 delete-key-pair --key-name "${keypair_name}"
+        log_info "Deleted keypair '${keypair_name}'."
+    fi
+}
+
+# Adds the given host name and IP address to the DNS for the given zone.
+aws_r53_add_host()
+{
+    local -r zone_name="$1"
+    local -r host_name="$2"
+    local -r host_ip="$3"
+    # Establish session
+    session_get
+    # Get the zone id
+    local -r zone_id="$(aws_r53_get_zone "${zone_name}")"
+    if [ "${zone_id}" != "" ] ; then
+        log_info "Updating host entry for '${host_name}' to '${host_ip}' for zone '${zone_name}' ..."
+        # Create the change file
+        local -r change_file="/tmp/r53_add_host.$(date +"%s").json"
+        cat << EOF > "${change_file}"
+{
+    "Comment": "Update record to reflect new IP for ${host_name}",
+    "Changes" : [
+         {
+             "Action": "UPSERT",
+             "ResourceRecordSet": {
+                 "Name": "${host_name}.${zone_name}",
+                 "Type": "A",
+                 "TTL": 60,
+                 "ResourceRecords": [
+                     {
+                         "Value": "${host_ip}"
+                     }
+                 ]
+             }
+         }
+    ]
+}
+EOF
+        # Submit for processing
+        local -r change_id="$(aws route53 change-resource-record-sets \
+            --hosted-zone-id "${zone_id}" \
+            --change-batch "file://${change_file}" \
+            --query ChangeInfo.Id \
+            --output text)"
+        log_info "Host entry '${host_name}' update requested. ChangeId=${change_id##*/}"
+        # Remove the temporary change file
+        rm -f "${change_file}"
+    else
+        log_warn "Zone '${zone_name}' doesn't exist."
+    fi
+}
+
+# Adds an alias for the given host name and target host to the DNS for the given
+#zone.
+aws_r53_add_host_alias()
+{
+    local -r zone_name="$1"
+    local -r host_name="$2"
+    local -r target_host="$3"
+    # Get the zone id
+    local -r zone_id="$(aws_r53_get_zone "${zone_name}")"
+    if [ "${zone_id}" != "" ] ; then
+        log_info "Updating host alias entry for '${host_name}' -> '${target_host}' for zone '${zone_name}' ..."
+        # Create the change file
+        local -r change_file="/tmp/r53_add_host_alias.$(date +"%s").json"
+        cat << EOF > "${change_file}"
+{
+    "Comment": "Update record to reflect new alias for ${target_host}",
+    "Changes" : [
+         {
+             "Action": "UPSERT",
+             "ResourceRecordSet": {
+                 "Name": "${host_name}.${zone_name}",
+                 "Type": "CNAME",
+                 "TTL": 3600,
+                 "ResourceRecords": [
+                     {
+                         "Value": "${target_host}"
+                     }
+                 ]
+             }
+         }
+    ]
+}
+EOF
+        # Submit for processing
+        local -r change_id="$(aws route53 change-resource-record-sets \
+            --hosted-zone-id "${zone_id}" \
+            --change-batch "file://${change_file}" \
+            --query ChangeInfo.Id \
+            --output text)"
+        log_info "Host entry '${host_name}' update requested. ChangeId=${change_id##*/}"
+        # Remove the temporary change file
+        rm -f "${change_file}"
+    else
+        log_warn "Zone '${zone_name}' doesn't exist."
+    fi
+}
+
+# Adds the given service name, port, protocol and FQHN to the DNS for the given zone.
+aws_r53_add_service()
+{
+    local -r zone_name="$1"
+    local -r srv_name="$2"
+    local -r srv_port="$3"
+    local -r srv_proto="$4"
+    local -r srv_host="$5"
+    # Get the zone id
+    local -r zone_id="$(aws_r53_get_zone "${zone_name}")"
+    if [ "${zone_id}" != "" ] ; then
+        log_info "Updating service entry for '${srv_name}:${srv_port}/${srv_proto}' for zone '${zone_name}' ..."
+        # Create the change file
+        local -r change_file="/tmp/r53_add_service.$(date +"%s").json"
+        cat << EOF > "${change_file}"
+{
+    "Comment": "Update record for ${srv_name}:${srv_port}/${srv_proto} -> ${srv_host}",
+    "Changes" : [
+         {
+             "Action": "UPSERT",
+             "ResourceRecordSet": {
+                 "Name": "_${srv_name}._${srv_proto}.${zone_name}",
+                 "Type": "SRV",
+                 "TTL": 300,
+                 "ResourceRecords": [
+                     {
+                         "Value": "0 100 ${srv_port} ${srv_host} "
+                     }
+                 ]
+             }
+         }
+    ]
+}
+EOF
+        # Submit for processing
+        local -r change_id="$(aws route53 change-resource-record-sets \
+            --hosted-zone-id "${zone_id}" \
+            --change-batch "file://${change_file}" \
+            --query ChangeInfo.Id \
+            --output text)"
+        log_info "Service entry '${srv_name}:${srv_port}/${srv_proto} -> ${srv_host}' update requested. ChangeId=${change_id##*/}"
+        # Remove the temporary change file
+        rm -f "${change_file}"
+    else
+        log_warn "Zone '${zone_name}' doesn't exist."
+    fi
+}
+
+# Creates a new private zone for the given VPC and with the given name.
+aws_r53_create_private_zone()
+{
+    local -r vpc_id="$1"
+    if [ "${vpc_id}" == "" ] ; then
+        return
+    fi
+    local -r zone_name="$2"
+    if [ "${zone_name}" == "" ] ; then
+        return
+    fi
+    local zone_id
+    zone_id=$(aws_r53_get_zone "${zone_name}")
+    if [ "${zone_id}" == "" ] ; then
+        # Zone doesn't exist create it
+        log_info "Creating private zone '${zone_name}' for VPC '${vpc_id}'..."
+        local -r deploy_date="$(date --utc +"%F %TZ")"
+        zone_id=$(aws route53 create-hosted-zone \
+            --name "${zone_name}" \
+            --vpc "VPCRegion=${AWS_REGION},VPCId=${vpc_id}" \
+            --caller-reference "$(date --utc --rfc-3339=ns)" \
+            --hosted-zone-config \
+                "PrivateZone=true,Comment=Deployed ${deploy_date} for ${PROJECT_ID}-${ENVIRONMENT}" \
+            --query "HostedZones[?Name=='${zone_name}.'].Id" \
+            --output text)
+        while [ "${zone_id}" == "None" ] ; do
+            zone_id="$(aws_r53_get_zone "${zone_name}")"
+            log_debug "Waiting for zone to become ready..."
+            sleep 2
+        done
+        zone_id="${zone_id##*/}"
+        # Tag the zone with the project id and environment
+        aws route53 change-tags-for-resource \
+            --resource-type hostedzone \
+            --resource-id "${zone_id}" \
+            --add-tags \
+                "Key=Name,Value=${PROJECT_ID}-${ENVIRONMENT} Private Zone" \
+                "Key=ProjectId,Value=${PROJECT_ID}" \
+                "Key=Environment,Value=${ENVIRONMENT}"
+        log_info "Created private zone '${zone_name}' for VPC '${vpc_id}' with id '${zone_id}'."
+    else
+        log_debug "Private zone '${zone_name}' already exists."
+    fi
+}
+
+# Creates a new public zone with the given name.
+aws_r53_create_public_zone()
+{
+    local -r zone_name="$1"
+    if [ "${zone_name}" == "" ] ; then
+        return
+    fi
+    local zone_id
+    zone_id=$(aws_r53_get_zone "${zone_name}")
+    if [ "${zone_id}" == "" ] ; then
+        # Zone doesn't exist create it
+        log_info "Creating public zone '${zone_name}' ..."
+        local -r deploy_date="$(date --utc +"%F %TZ")"
+        zone_id=$(aws route53 create-hosted-zone \
+            --name "${zone_name}" \
+            --caller-reference "$(date --utc --rfc-3339=ns)" \
+            --hosted-zone-config \
+                Comment="Deployed ${deploy_date} for ${PROJECT_ID}-${ENVIRONMENT}" \
+            --query "HostedZones[?Name=='${zone_name}.'].Id" \
+            --output text)
+        while [ "${zone_id}" == "None" ] ; do
+            zone_id="$(aws_r53_get_zone "${zone_name}")"
+            log_debug "Waiting for zone to become ready..."
+            sleep 2
+        done
+        zone_id="${zone_id##*/}"
+        # Tag the zone with the project id and environment
+        aws route53 change-tags-for-resource \
+            --resource-type hostedzone \
+            --resource-id "${zone_id}" \
+            --add-tags \
+                "Key=Name,Value=${PROJECT_ID}-${ENVIRONMENT} Public Zone" \
+                "Key=ProjectId,Value=${PROJECT_ID}" \
+                "Key=Environment,Value=${ENVIRONMENT}"
+        log_info "Created public zone '${zone_name}' with id '${zone_id}'."
+    else
+        log_debug "Public zone '${zone_name}' already exists."
+    fi
+}
+
+# Gets id for the zone with the given name, or nothing if it doesn't exist.
+aws_r53_get_zone()
+{
+    local -r zone_name="$1"
+    if [ "${zone_name}" == "" ] ; then
+        return
+    fi
+    local -r zone_id=$(aws route53 list-hosted-zones \
+        --query "HostedZones[?Name=='${zone_name}.'].Id" \
+        --output text)
+    echo "${zone_id##*/}"
+}
+
+# Gets the nameservers for the zone with the given name, or nothing if no such
+# zone exists.
+aws_r53_get_zone_ns()
+{
+    local -r zone_name="$1"
+    if [ "${zone_name}" == "" ] ; then
+        return
+    fi
+    local -r zone_id="$(aws_r53_get_zone "${zone_name}")"
+    if [ "${zone_id}" != "" ] ; then
+        local -r zone_ns="$(aws route53 get-hosted-zone \
+            --id "${zone_id}" \
+            --query DelegationSet.NameServers \
+            --output text)"
+        echo "${zone_ns}"
+    fi
+}
+
+# Removes the zone with the given name, if it exists. This assumes that the zone
+# has no resource records, i.e. it will only remove zones that are empty. The
+# deleted zone will enter a PENDING state - this function returns the Change Id,
+# but does not wait for the deletion to complete.
+aws_r53_remove_zone()
+{
+    local -r zone_name="$1"
+    local -r zone_id="$(aws_r53_get_zone "${zone_name}")"
+    if [ "${zone_id}" != "" ] ; then
+        # Remove the zone
+        log_info "Requesting removal of zone '${zone_name}' ..."
+        local -r change_id="$(aws route53 delete-hosted-zone \
+            --id "${zone_id##*/}" \
+            --query "ChangeInfo.Id" --output text)"
+        log_info "Zone '${zone_name}' is being removed. ChangeId=${change_id##*/}."
+    else
+        log_debug "Zone '${zone_name}' doesn't exist."
+    fi
+}
+
+aws_r53_remove_zone_records()
+{
+    local -r zone_name="$1"
+    local -r zone_id="$(aws_r53_get_zone "${zone_name}")"
+    if [ "${zone_id}" != "" ] ; then
+        # Remove all the records for the zone, except NS and SOA
+        log_info "Requesting removal of all records for zone '${zone_name}' ..."
+        local change_id
+        aws route53 list-resource-record-sets --hosted-zone-id "${zone_id}" |
+            jq -c '.ResourceRecordSets[]' |
+        while read -r r_recordset; do
+            # shellcheck disable=SC2005
+            # shellcheck disable=SC2046
+            read -r name type <<<$(echo "$(jq -r '.Name,.Type' <<<"${r_recordset}")")
+            if [ "${type}" != "NS" ] && [ "${type}" != "SOA" ]; then
+                change_id="$(aws route53 change-resource-record-sets \
+                    --hosted-zone-id "${zone_id}" \
+                    --change-batch '{"Changes":[{"Action":"DELETE","ResourceRecordSet":
+                      '"${r_recordset}"'
+                    }]}' \
+                    --output text --query 'ChangeInfo.Id')"
+                log_info "Record '${name}' is being removed. ChangeId=${change_id##*/}."
+            fi
+        done
+    else
+        log_debug "Zone '${zone_name}' doesn't exist."
+    fi
+}
+
+# Gets the current AWS session or requests a new one if none existing.
+aws_session_get()
+{
+    # See if we need to authenticate
+    if [ ! -s "${MACHINE_CREDENTIALS_FILE}" ] ; then
+        if [ "${MFA_AUTH_ENABLED}" == "true" ] ; then
+            aws_auth_mfa
+        else
+            aws_auth
+        fi
+    fi
+    # Set env var values based on credentials file
+    export AWS_ACCESS_KEY_ID
+    AWS_ACCESS_KEY_ID="$(cut "${MACHINE_CREDENTIALS_FILE}" -f2)"
+    export AWS_SESSION_EXPIRY_DATE
+    AWS_SESSION_EXPIRY_DATE="$(cut "${MACHINE_CREDENTIALS_FILE}" -f3)"
+    export AWS_SECRET_ACCESS_KEY
+    AWS_SECRET_ACCESS_KEY="$(cut "${MACHINE_CREDENTIALS_FILE}" -f4)"
+    export AWS_SESSION_TOKEN
+    AWS_SESSION_TOKEN="$(cut "${MACHINE_CREDENTIALS_FILE}" -f5)"
+    log_debug "AccessKey       = ${AWS_ACCESS_KEY_ID}"
+    log_debug "ExpiryDate      = ${AWS_SESSION_EXPIRY_DATE}"
+    log_debug "SecretAccessKey = ${AWS_SECRET_ACCESS_KEY}"
+    log_debug "SessionToken    = ${AWS_SESSION_TOKEN}"
+    # Check if the credentials have expired and re-auth if they have
+    local -r now=$(date --utc +"%s")
+    local -r expiry=$(date --utc -d "${AWS_SESSION_EXPIRY_DATE}" +"%s")
+    if [ "${now}" -ge "${expiry}" ] ; then
+        log_info "Existing session expired, refreshing..."
+        session_refresh
+    fi
+}
+
+# Removes the current AWS session from the environment.
+aws_session_rm()
+{
+    # Wipe the current AWS environment context
+    unset AWS_ACCESS_KEY_ID
+    unset AWS_SECRET_ACCESS_KEY
+    unset AWS_SESSION_EXPIRY_DATE
+    unset AWS_SESSION_TOKEN
+}
+
+# Adds an ingress rule for the given security group, protocol, port(s) and cidr.
+# The 'port' parameter can either be a single port or a range, given as
+# 'min-max', e.g. '0-1024'.
+aws_sg_authorize_ingress()
+{
+    local -r sg_id="$1"
+    local -r proto="$2"
+    local -r port="$3"
+    local -r cidr="$4"
+    local -r port_from="$(echo "${port}" | cut -d- -f1)"
+    local -r port_to="$(echo "${port}" | cut -d- -f2)"
+    if [ "$(aws ec2 describe-security-groups \
+            --filters \
+                "Name=group-id,Values=${sg_id}" \
+                "Name=ip-permission.protocol,Values=${proto}" \
+                "Name=ip-permission.from-port,Values=${port_from}" \
+                "Name=ip-permission.to-port,Values=${port_to}" \
+                "Name=ip-permission.cidr,Values=${cidr}" \
+            --query 'SecurityGroups[*].GroupId' \
+            --output text)" == "" ] ; then
+        # Create the ingress rule for the security group
+        aws ec2 authorize-security-group-ingress \
+            --group-id "${sg_id}" --protocol "${proto}" --port "${port}" \
+            --cidr "${cidr}"
+    fi
+}
+
+# Creates a new security group with the given name if it doesn't already exist.
+aws_sg_create()
+{
+    local -r sg_name="$1"
+    local sg_id
+    sg_id="$(aws_sg_get "${sg_name}")"
+    if [ "${sg_id}" == "" ] ; then
+        # Create the security group ...
+        sg_id="$(aws ec2 create-security-group \
+            --group-name "${sg_name}" \
+            --description "Security group for ${sg_name}" \
+            --vpc-id "${VPC_ID}" \
+            --query 'GroupId' \
+            --output text)"
+        # ... and tag it
+        aws_ec2_tag_resource "${sg_id}" \
+            "${sg_name}" "${PROJECT_ID}" "${ENVIRONMENT}"
+    fi
+    echo "${sg_id}"
+}
+
+# Forcibly removes the security group with the given name, waiting indefinitely
+# for it to become unused before removing it. This will block if the security
+# group cannot be removed.
+aws_sg_destroy()
+{
+    local -r sg_name="$1"
+    local -r sg_id="$(aws_sg_get "${sg_name}")"
+    if [ "${sg_id}" != "" ] ; then
+        # Check if the SG is explicitly in use, and wait until it's not
+        while [ "$(aws_sg_in_use "${sg_name}")" == "true" ] ; do
+            log_info "Waiting for security group '${sg_name}' to become unused..."
+            sleep 8
+        done
+        # Even after EC2 instances have been terminated, SG can still error when
+        # attempting to remove it. We therefore capture the stdout and handle these
+        # errors
+        log_info "Removing security group '${sg_name}'..."
+        local status
+        status="$(aws ec2 delete-security-group --group-id "${sg_id}" 2>&1)"
+        local removed
+        # Handle any errors whilst removing the SG
+        until [ "$removed" == "true" ] ; do
+            if [ "${status}" == "" ] ; then
+                # No output means no error, SG has been removed
+                log_info "Removed security group '${sg_name}'."
+                removed="true"
+            elif echo "${status}" | grep -q DependencyViolation ; then
+                # DependencyViolation error - SG is still shown as in use
+                log_info "Waiting for security group '${sg_name}' to become free..."
+                sleep 4
+                status="$(aws ec2 delete-security-group --group-id "${sg_id}" 2>&1)"
+            else
+                # Unhandled status message
+                log_error "Unhandled status whilst removing security group '${sg_name}': ${status}"
+                break
+            fi
+        done
+    fi
+}
+
+# Gets the security group id for the given name, if one exists.
+aws_sg_get()
+{
+    local sg_name="$1"
+    aws ec2 describe-security-groups \
+        --filters "Name=group-name,Values=${sg_name}" \
+        --query "SecurityGroups[*].GroupId"\
+        --output text
+}
+
+# Returns true if the security group with the given name is in use.
+aws_sg_in_use()
+{
+    local -r sg_name="$1"
+    local -r sg_id="$(aws_sg_get "${sg_name}")"
+    if [ ! -z "${sg_id}" ] ; then
+        # See if there are any EC2 instances using the group
+        if [ "$(aws ec2 describe-instances --query \
+           'Reservations[*].Instances[*].SecurityGroups[*].GroupId' \
+           --output text \
+           | grep "${sg_id}")" != "" ] ; then
+            echo "true"
+        # See if there are any EC2 network interfaces using the group
+        elif [ "$(aws ec2 describe-network-interfaces \
+           --filters "Name=group-id,Values=${sg_id}" \
+           --query  'NetworkInterfaces[*].NetworkInterfaceId' \
+           --output text)" != "" ] ; then
+            echo "true"
+        fi
+    fi
+}
+
+# Removes the security group for the given name, if one exists.
+aws_sg_remove()
+{
+    local -r sg_name="$1"
+    local -r sg_id="$(aws_sg_get "${sg_name}")"
+    if [ "${sg_id}" != "" ] ; then
+        log_info "Removing security group '${sg_name}'..."
+        aws ec2 delete-security-group --group-id "${sg_id}"
+        log_info "Removed security group '${sg_name}'."
+    fi
+}
+
+# Gets the CIDR for the VPC with the given id.
+aws_vpc_get_cidr()
+{
+    local -r vpc_id="$1"
+    aws ec2 describe-vpcs \
+        --vpc-ids "${vpc_id}" \
+        --query 'Vpcs[0].CidrBlock' \
+        --output text
+}
+
+# Gets the id of the subnet with the given 'index' (as returned by the AWS API)
+# for the given VPC.
+aws_vpc_get_subnet()
+{
+    local -r vpc_id="$1"
+    local -r subnet_index="$2"
+    aws ec2 describe-subnets \
+        --filters "Name=vpc-id,Values=${vpc_id}" \
+        --query "Subnets[${subnet_index}].SubnetId" \
+        --output text
+}
+
+_LIB_AWS_SH="LOADED"
+log_debug "Loaded lib-aws"
+fi # END

--- a/aws/machine/lib/lib-config.sh
+++ b/aws/machine/lib/lib-config.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Handles configuration for deployment tools
+#
+
+# Only load this library once
+if [ -z "${_LIB_CONFIG_SH}" ] ; then
+
+LIB_DIR="$( cd "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" && pwd )"
+
+# Include dependencies
+# shellcheck source=./lib/lib-logging.sh
+source "${LIB_DIR}/lib-logging.sh"
+
+# Config file to read deployment config from
+DEPLOYMENT_CONF="${SCRIPT_DIR}/etc/deployment.conf"
+
+# Path of file used to store AWS credentials
+# shellcheck disable=SC2034
+MACHINE_CREDENTIALS_FILE=".machine-credentials"
+
+# Read config from file
+if [ -f "${DEPLOYMENT_CONF}" ] ; then
+    log_info "Reading deployment configuration from ${DEPLOYMENT_CONF}"
+    # shellcheck source=./etc/deployment.conf.template
+    source "${DEPLOYMENT_CONF}"
+else
+    log_fatal "Unable to read config from '${DEPLOYMENT_CONF}', exiting."
+fi
+
+
+_LIB_CONFIG_SH="LOADED"
+log_debug "Loaded lib-config"
+fi # END

--- a/aws/machine/lib/lib-docker.sh
+++ b/aws/machine/lib/lib-docker.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+
+#
+# Functions related to remote docker and docker machine operations.
+#
+
+# Only load this library once
+if [ -z "${_LIB_DOCKER_SH}" ] ; then
+
+LIB_DIR="$( cd "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" && pwd )"
+
+# Include dependencies
+
+# shellcheck source=./lib/lib-aws.sh
+source "${LIB_DIR}/lib-aws.sh"
+
+# shellcheck source=./lib/lib-config.sh
+source "${LIB_DIR}/lib-config.sh"
+
+# Docker #######################################################################
+
+# Checks that required dependencies are installed on the remote Docker host
+check_dockerhost_dependencies()
+{
+    # See http://docs.ansible.com/ansible/latest/intro_installation.html#latest-releases-via-apt-ubuntu
+    # We also include:
+    #  - cifs-utils
+    #  - make
+    #  - nfs-common
+    #  - python-pip
+    #  - s3fs
+    # We also make the `ubuntu` user part of the `docker` group
+    docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+        "sudo apt-add-repository -y ppa:ansible/ansible && \
+        sudo apt update && \
+        sudo apt install -y \
+            ansible \
+            cifs-utils \
+            make \
+            nfs-common \
+            python-pip \
+            s3fs \
+            software-properties-common && \
+        sudo usermod -a -G docker ubuntu && \
+        sudo -H pip install -U pip docker-compose"
+}
+
+# Checks, and if necessary creates, a registry on the remote Docker host.
+docker_check_registry()
+{
+    local registry_url="http://localhost:5000"
+    while [ "$(docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+            curl -s "${registry_url}/v2/" >/dev/null 2>&1 ; echo $?)" -eq 1 ] ; do
+        log_info "Docker Registry unavailable, creating"
+        # Set Docker to use our EC2 instance and build and run the containers
+        eval "$(docker-machine env "${DOCKERHOST_INSTANCE}")"
+        # Create the registry
+        docker run -d -p 5000:5000 --name registry registry:2
+    done
+    log_info "Docker Registry is ready and available at ${registry_url}."
+}
+
+# Gets the public port for the given service name and private port.
+docker_get_service_port()
+{
+    local -r service="$1"
+    local -r private_port="$2"
+    local compose_files
+    compose_files="docker-compose.qa.yml:docker-compose.nextcloud.yml"
+    if [ "${SHIB_ENABLED}" == "true" ] ; then
+        compose_files="${compose_files}:docker-compose.am-shib.yml"
+        compose_files="${compose_files}:docker-compose.shib-local.yml"
+    fi
+    docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+        "cd ~/src/rdss-archivematica/compose && \
+            export COMPOSE_FILE=${compose_files} ; \
+            docker-compose port ${service} ${private_port} | cut -d: -f2"
+}
+
+# Gets the current status of the remote Docker host. If the host is currently
+# starting or stopping then this will block and wait until it enters a stable
+# state.
+docker_machine_get_status()
+{
+    docker_machine_wait_for_status "Starting Stopping"
+}
+
+# Provisions or restarts the remote Docker host machine.
+docker_machine_provision()
+{
+    local machine_status
+    local instance_id
+    instance_id="$(aws_ec2_get_id_for_instance_name "${DOCKERHOST_INSTANCE}")"
+    if [ "${instance_id}" == "" ] ; then
+        # No instance exists, don't bother asking for status
+        machine_status="NotExist"
+    else
+        # Instance exists, check status
+        machine_status="$(docker_machine_get_status)"
+    fi
+    case $machine_status in
+        "Error")
+            # Unknown error, abort
+            log_error "Unknown error whilst provisioning ${DOCKERHOST_INSTANCE}, exiting."
+            return 1
+            ;;
+        "NotExist")
+            # Provision new EC2 instance to run docker
+            docker-machine create \
+                --driver amazonec2 \
+                --amazonec2-region "${AWS_REGION}" \
+                --amazonec2-instance-type "${DOCKERHOST_INSTANCE_TYPE}" \
+                --amazonec2-root-size "${DOCKERHOST_ROOT_SIZE:-16}" \
+                --amazonec2-security-group "${DOCKERHOST_INSTANCE}" \
+                --amazonec2-ssh-keypath "${SSH_KEY_PATH}" \
+                --amazonec2-tags \
+                     "Name,${DOCKERHOST_INSTANCE},Environment,${ENVIRONMENT},ProjectId,${PROJECT_ID}" \
+                --amazonec2-vpc-id "${VPC_ID}" \
+                --engine-storage-driver overlay2 \
+                "${DOCKERHOST_INSTANCE}" && docker_machine_wait_for_status "Starting"
+            instance_id="$(aws_ec2_get_id_for_instance_name "${DOCKERHOST_INSTANCE}")"
+            log_debug "Dockerhost '${DOCKERHOST_INSTANCE}' has instance id '${instance_id}'"
+            # If we got an instance id (or ids) then iterate through them to confirm
+            # they are or it is in a running state (multiple ids can happen if instances
+            # are stopped/started in quick succession or if a AWS limit is hit).
+            # shellcheck disable=SC2001
+            for i_id in $(echo "${instance_id}" | sed "s/$/ /g") ; do
+                local i_state
+                i_state="$(aws_ec2_get_instance_state "${i_id}")"
+                if [ "${i_state}" != "running" ] ; then
+                    # Remove the instance from the instance ids list
+                    log_debug "Instance ${i_id} is in state ${i_state}, ignoring."
+                    instance_id="$(echo "${instance_id}" | sed "s/${i_id}//")"
+                fi
+            done
+            # Tag the volume(s) created by docker-machine
+            local -r vol_ids="$(aws_ec2_get_instance_attached_volumes "${instance_id}")"
+            local vol_index
+            vol_index=0
+            for v_id in $vol_ids ; do
+                aws_ec2_tag_resource "${v_id}" \
+                    "${DOCKERHOST_INSTANCE}-disk-${vol_index}" "${PROJECT_ID}" "${ENVIRONMENT}"
+                    vol_index="$((vol_index + 1))"
+            done
+            # Also tag the security group created by docker-machine
+            local -r sg_id="$(aws_sg_get "${DOCKERHOST_INSTANCE}")"
+            aws_ec2_tag_resource "${sg_id}" \
+                    "${DOCKERHOST_INSTANCE}" "${PROJECT_ID}" "${ENVIRONMENT}"
+            ;;
+        "Stopped")
+            # Start existing EC2 instance again ready for use
+            docker-machine start "${DOCKERHOST_INSTANCE}" && \
+                docker_machine_get_status
+            # Regenerate certs because the IP address will have changed
+            docker-machine regenerate-certs -f "${DOCKERHOST_INSTANCE}"
+            ;;
+        "Running")
+            # EC2 instance already running, nothing to do
+            log_info "${DOCKERHOST_INSTANCE} already running..."
+            ;;
+        "UnauthorizedOperation")
+            # User doesn't have authority for this operation
+            log_error "Insufficient access to provision ${DOCKERHOST_INSTANCE}, exiting."
+            return 1
+            ;;
+        *)
+            log_error "Unhandled machine status '$machine_status' in provision"
+            return 1
+            ;;
+    esac
+}
+
+# Stops the remote Docker host machine.
+docker_machine_stop()
+{
+    local machine_status
+    local -r instance_id="$(aws_ec2_get_id_for_instance_name "${DOCKERHOST_INSTANCE}")"
+    if [ "${instance_id}" == "" ] ; then
+        # No instance exists, don't bother asking for status
+        machine_status="NotExist"
+    else
+        # Instance exists, check status
+        machine_status="$(docker_machine_get_status)"
+    fi
+    case $machine_status in
+        "Error")
+            # Unknown error, abort
+            log_fatal "Unknown error whilst stopping ${DOCKERHOST_INSTANCE}, exiting."
+            ;;
+        "NotExist")
+            # EC2 instance doesn't exist, nothing to do
+            log_debug "${DOCKERHOST_INSTANCE} doesn't exist, nothing to stop."
+            ;;
+        "Stopped")
+            # EC2 instance already stopped, nothing to do
+            log_info "${DOCKERHOST_INSTANCE} already stopped, nothing to do."
+            ;;
+        "Running")
+            # EC2 instance running, stop it
+            log_info "${DOCKERHOST_INSTANCE} is running, stopping..."
+            docker-machine stop "${DOCKERHOST_INSTANCE}" && \
+                docker_machine_get_status
+            ;;
+        "UnauthorizedOperation")
+            # User doesn't have authority for this operation
+            log_fatal "Insufficient access to stop ${DOCKERHOST_INSTANCE}, exiting."
+            ;;
+        *)
+            log_fatal "Unhandled machine status '$machine_status' in stop"
+            ;;
+    esac
+}
+
+# Removes the remote Docker host machine. It does not force removal if the
+# instance is still running.
+docker_machine_remove()
+{
+    local machine_status
+    local -r instance_id="$(aws_ec2_get_id_for_instance_name "${DOCKERHOST_INSTANCE}")"
+    if [ "${instance_id}" == "" ] ; then
+        # No instance exists, don't bother asking for status
+        machine_status="NotExist"
+    else
+        # Instance exists, check status
+        machine_status="$(docker_machine_get_status)"
+    fi
+    case $machine_status in
+        "Error")
+            # Unknown error, abort
+            log_fatal "Unknown error whilst removing ${DOCKERHOST_INSTANCE}, exiting."
+            ;;
+        "NotExist")
+            # EC2 instance doesn't exist
+            if [ -e "${HOME}/.docker/machine/machines/${DOCKERHOST_INSTANCE}/" ] ; then
+                # Docker machine still has local reference to the instance, remove it
+                log_info "${DOCKERHOST_INSTANCE} no longer exists, removing..."
+                docker-machine rm -y "${DOCKERHOST_INSTANCE}" \
+                    && docker_machine_wait_for_status "Stopping"
+            fi
+            # Destroy the security group, if it still exists
+            aws_sg_destroy "${DOCKERHOST_INSTANCE}"
+            ;;
+        "Stopped")
+            # EC2 instance stopped, remove it
+            log_info "${DOCKERHOST_INSTANCE} is stopped, removing..."
+            docker-machine rm -y "${DOCKERHOST_INSTANCE}" \
+                && docker_machine_wait_for_status "Stopping"
+            # Also ensure that the security group is destroyed
+            aws_sg_destroy "${DOCKERHOST_INSTANCE}"
+            ;;
+        "Running")
+            # EC2 instance running, can't remove
+            log_fatal "${DOCKERHOST_INSTANCE} is still running, cannot remove, aborting."
+            ;;
+        "UnauthorizedOperation")
+            # User doesn't have authority for this operation
+            log_fatal "Insufficient access to remove ${DOCKERHOST_INSTANCE}, exiting."
+            ;;
+        *)
+            log_fatal "Unhandled machine status '$machine_status' in remove"
+            ;;
+    esac
+}
+
+# Updates the Docker Machine amazonec2 driver authentication config. This is
+# necessary to avoid stale AWS session values being kept when a session is
+# refreshed.
+docker_machine_update_driver_auth_config()
+{
+    local dm_config_file="${HOME}/.docker/machine/machines/${DOCKERHOST_INSTANCE}/config.json"
+    if [ -f "${dm_config_file}" ] ; then
+        local tmp_file="/tmp/.docker-machine.config.tmp"
+        # The Docker Machine config keeps stale AWS credentials, which result in
+        # RequestExpired errors. We therefore update it when we refresh the session.
+        sed -r "s|AccessKey\": \"[^\"]+|AccessKey\": \"${AWS_ACCESS_KEY_ID}|" "${dm_config_file}" | \
+            sed -r "s|SecretKey\": \"[^\"]+|SecretKey\": \"${AWS_SECRET_ACCESS_KEY}|" | \
+            sed -r "s|SessionToken\": \"[^\"]+|SessionToken\": \"${AWS_SESSION_TOKEN}|" \
+            > "${tmp_file}"
+        cp "${tmp_file}" "${dm_config_file}" \
+            && rm "${tmp_file}"
+    fi
+}
+
+# Blocks and waits until the remote Docker host reaches a state other than the
+# given wait_states.
+docker_machine_wait_for_status()
+{
+    local -r wait_states="$1"
+    local status
+    status="$(docker-machine status "${DOCKERHOST_INSTANCE}" 2>&1)"
+    # Handle error conditions
+    if echo "${status}" | grep -q 'UnauthorizedOperation' ; then
+        # User account isn't authorized to execute this operations
+        echo "UnauthorizedOperation"
+        return 1
+    fi
+    if echo "${status}" | grep -q 'not exist' ; then
+        # Machine instance doesn't exist
+        echo "NotExist"
+        return 1
+    fi
+    if echo "${status}" | grep -q 'error' ; then
+        log_warn "Handling error: ${status}"
+        if [ "$(echo "${status}" | grep 'RequestExpired')" != "" ] ; then
+            log_warn "Current request has expired, renewing session"
+            status="error:request-expired"
+            session_refresh && docker_machine_wait_for_status "${wait_states}"
+        fi
+    fi
+    # Wait for intermediate states to transition
+    while [ "$(echo "${wait_states}" | grep "${status}")" != "" ] ; do
+        log_info "$status ${DOCKERHOST_INSTANCE} ..."
+        sleep 4
+        status="$(docker-machine status "${DOCKERHOST_INSTANCE}" 2>&1)"
+    done
+    echo "${status}"
+}
+
+
+_LIB_DOCKER_SH="LOADED"
+log_debug "Loaded lib-docker"
+fi # END

--- a/aws/machine/lib/lib-logging.sh
+++ b/aws/machine/lib/lib-logging.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+#
+# Functions related to logging.
+#
+
+# Only load this library once
+if [ -z "${_LIB_LOGGING_SH}" ] ; then
+
+# Log output
+LOG_OUTFILE=${LOG_OUTFILE:-"$(pwd)/logs/${PROGNAME}-$(date --utc +"%y%m%d%H%M%S").log"}
+mkdir -p "$(dirname "${LOG_OUTFILE}")"
+
+# Logging ######################################################################
+
+log_alert()
+{
+    log_msg "\\e[101mALERT\\e[0m" "\\e[101m${1}\\e[0m"
+}
+
+log_debug()
+{
+    if [ -n "${DEBUG}" ] ; then
+        log_msg "\\e[37mDEBUG" "${1}\\e[0m"
+    fi
+}
+
+log_error()
+{
+    log_msg "\\e[91mERROR\\e[0m" "${1}"
+}
+
+log_fatal()
+{
+    log_msg "\\e[95mFATAL\\e[0m" "${1}"
+    exit 1
+}
+
+log_info()
+{
+    log_msg "\\e[92mINFO \\e[0m" "${1}"
+}
+
+log_msg()
+{
+    local -r level="$1"
+    local -r msg="[$(date --utc +"%Y-%m-%d %H:%M:%S")Z] [${level}] $2"
+    >&2 echo -e "${msg}"
+    # Remove control characters before writing to file
+    stripfmt "${msg}" >> "${LOG_OUTFILE}"
+}
+
+log_note()
+{
+    log_msg "\\e[96mNOTE \\e[0m" "\\e[96m${1}\\e[0m"
+}
+
+log_warn()
+{
+    log_msg "\\e[33mWARN \\e[0m" "${1}"
+}
+
+stripfmt()
+{
+    echo -e "$1" | sed -r "s/\\x1B\\[([0-9];)?([0-9]{1,3}(;[0-9]{1,3})?)?[mGK]//g"
+}
+
+_LIB_LOGGING_SH="LOADED"
+log_debug "Loaded lib-logging"
+fi # END

--- a/aws/machine/lib/lib-remote-mounts.sh
+++ b/aws/machine/lib/lib-remote-mounts.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+#
+# Functions related to the management of mounted filesystems on remote machines.
+#
+
+# Only load this library once
+if [ -z "${_LIB_REMOTE_MOUNTS_SH}" ] ; then
+
+LIB_DIR="$( cd "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" && pwd )"
+
+# Include dependencies
+# shellcheck source=./lib/lib-config.sh
+source "${LIB_DIR}/lib-config.sh"
+
+# Remote mounts ################################################################
+
+remote_add_mount()
+{
+    local -r device_path="$1"
+    local -r mount_path="$2"
+    local -r mount_type="$3"
+    local -r mount_opts="$4"
+    local -r fstab_entry="${device_path}	${mount_path}	${mount_type}	${mount_opts}"
+    log_info "Adding mount '${mount_path}'..."
+    log_debug "Checking fstab entry: ${fstab_entry}"
+    # Check if there is already an fstab entry for this mount path
+    if [ "$(docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+            "grep ${mount_path} /etc/fstab" 2>/dev/null)" != "" ] ; then
+        # Mount already exists for given mount path, replace it
+        log_debug "Replacing ${fstab_entry}"
+        docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+            "cp /etc/fstab /tmp/fstab.new && \
+            sed 's|.*${mount_path}.*|${fstab_entry}|' /etc/fstab > \
+            /tmp/fstab.new"
+    else
+        # Mount doesn't already exist, append it
+        log_debug "Adding ${fstab_entry}"
+        docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+            "cp /etc/fstab /tmp/fstab.new && echo '${fstab_entry}' >> /tmp/fstab.new"
+    fi
+    # Update the fstab file with the new mount point
+    docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+        sudo mv -f /tmp/fstab.new /etc/fstab
+    # Create the mount path folder if necessary
+    docker-machine ssh "${DOCKERHOST_INSTANCE}" "sudo mkdir -p ${mount_path}"
+    # Mount or remount the mount path as necessary
+    if [ "$(docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+            "mount | grep ${mount_path} " 2>/dev/null)" != "" ] ; then
+        # Mount path is already mounted, unmount before mounting
+        docker-machine ssh "${DOCKERHOST_INSTANCE}" sudo umount -l "${mount_path}"
+    fi
+    log_info "Mounting '${mount_path}'..."
+    docker-machine ssh "${DOCKERHOST_INSTANCE}" sudo mount "${mount_path}"
+}
+
+remote_mount_arkivum()
+{
+    local -r arkivum_host="$1"
+    # Add the fstab entry for the given arkivum host and mount as a CIFS share
+    remote_add_mount "//${arkivum_host}/astor" \
+        "/mnt/astor" \
+        "cifs" \
+        "defaults,guest,file_mode=0666,dir_mode=0777,rw 0 1"
+}
+
+remote_mount_nfs()
+{
+    local -r nfs_host="$1"
+    # Add the fstab entry for the given nfs host and mount
+    remote_add_mount "${nfs_host}:/mnt/nfs" \
+        "/mnt/nfs" \
+        "nfs" \
+        "auto,noatime,nolock,bg,nfsvers=4,tcp,intr"
+}
+
+remote_mount_s3fs()
+{
+    local -r s3_bucket_params="$1"
+    if [ "${s3_bucket_params}" != "" ] ; then
+        local -r s3_bucket_name="$(echo "$s3_bucket_params" | cut -d: -f1)"
+        local -r s3_access_key_id="$(echo "$s3_bucket_params" | cut -d: -f2)"
+        local -r s3_secret_key="$(echo "$s3_bucket_params" | cut -d: -f3)"
+        local -r s3_bucket_mount_name="$(echo "$s3_bucket_params" | cut -d: -f4)"
+        # Add the AWS credentials config (assumes all s3 buckets use same credentials)
+        log_info "Updating S3FS credentials..."
+        docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+            "echo '${s3_bucket_name}:${s3_access_key_id}:${s3_secret_key}' > /tmp/passwd-s3fs && \
+                sudo mv /tmp/passwd-s3fs /etc/passwd-s3fs && chmod 640 /etc/passwd-s3fs"
+        # Add the fstab entry and mount
+        remote_add_mount "${s3_bucket_name}" \
+            "/mnt/s3/${s3_bucket_mount_name}" \
+            "fuse.s3fs" \
+            "_netdev,allow_other,ro,uid=33,gid=33,umask=0000,no_check_certificate 0 0"
+    fi
+}
+
+_LIB_REMOTE_MOUNTS_SH="LOADED"
+log_debug "Loaded lib-remote-mounts"
+fi # END

--- a/aws/machine/lib/lib-session.sh
+++ b/aws/machine/lib/lib-session.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#
+# Functions related to the combined management of AWS and Docker Machine 
+# sessions and credentials.
+#
+
+# Only load this library once
+if [ -z "${_LIB_SESSION_SH}" ] ; then
+
+LIB_DIR="$( cd "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" && pwd )"
+
+# Include dependencies
+# shellcheck source=./lib/lib-config.sh
+source "${LIB_DIR}/lib-config.sh"
+
+# Session handling #############################################################
+
+session_get()
+{
+    # Get or create our AWS session
+    aws_session_get
+    # Update the Docker Machine config with new credentials
+    docker_machine_update_driver_auth_config
+}
+
+# Removes the old session and gets a new one
+session_refresh()
+{
+    session_rm && session_get
+}
+
+session_rm()
+{
+    # Remove the AWS session
+    aws_session_rm
+    # Remove our credentials file
+    rm -f "${MACHINE_CREDENTIALS_FILE}"
+}
+
+_LIB_SESSION_SH="LOADED"
+log_debug "Loaded lib-session"
+fi # END

--- a/aws/machine/lib/libs.sh
+++ b/aws/machine/lib/libs.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#
+# Main include file for library functions. This includes all other libraries.
+#
+
+# Only load this library once
+if [ -z "${_LIB_LIBS_SH}" ] ; then
+
+LIB_DIR="$( cd "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" && pwd )"
+
+# Import the individual module files
+# shellcheck source=./lib/lib-aws.sh
+source "${LIB_DIR}/lib-aws.sh"
+# shellcheck source=./lib/lib-config.sh
+source "${LIB_DIR}/lib-config.sh"
+# shellcheck source=./lib/lib-docker.sh
+source "${LIB_DIR}/lib-docker.sh"
+# shellcheck source=./lib/lib-logging.sh
+source "${LIB_DIR}/lib-logging.sh"
+# shellcheck source=./lib/lib-remote-mounts.sh
+source "${LIB_DIR}/lib-remote-mounts.sh"
+# shellcheck source=./lib/lib-session.sh
+source "${LIB_DIR}/lib-session.sh"
+
+_LIB_LIBS_SH="LOADED"
+log_debug "Loaded libs"
+fi # END

--- a/aws/machine/teardown.sh
+++ b/aws/machine/teardown.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+#
+# Tears down all of the resources associated with a deployed Arkivum appliance,
+# NFS server and dockerhost. May also optionally destroy storage volumes too.
+#
+# Usage:
+#
+# To override the project id for the resources to tear down
+#    PROJECT_ID=1234 ./teardown.sh
+#
+# To also remove the EBS storage used by the NFS server (removing ALL data!)
+#    DESTROY_VOLUMES=yes PROJECT_ID=1234 ./teardown.sh
+#
+
+# shellcheck disable=SC2034
+PROGNAME="$(basename "${BASH_SOURCE[0]}" | cut -d. -f1)"
+SCRIPT_DIR="$( cd "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" && pwd )"
+
+# Include library modules
+# shellcheck source=./lib/libs.sh
+source "${SCRIPT_DIR}/lib/libs.sh"
+
+# Tear down ####################################################################
+
+destroy_containers() {
+    # Use make to destroy the containers and their non-external volumes
+    docker-machine ssh "${DOCKERHOST_INSTANCE}" \
+        "if [ -e ~/src/rdss-archivematica/compose ] ; then \
+            cd ~/src/rdss-archivematica/compose ; \
+            export VOL_BASE=\$(pwd) ; \
+            export DOMAIN_NAME=${PUBLIC_DOMAIN_NAME} ; \
+            export DOMAIN_ORGANISATION=${DOMAIN_ORGANISATION} ; \
+            export NGINX_EXTERNAL_IP='0.0.0.0' ; \
+            export IDP_EXTERNAL_IP='0.0.0.0' ; \
+            export IDP_EXTERNAL_PORT=6443 ; \
+                make destroy \
+                    SHIBBOLETH_CONFIG=${SHIBBOLETH_CONFIG} \
+                    NEXTCLOUD_ENABLED=true ; \
+        fi"
+}
+
+teardown_arkivum()
+{
+    log_info "Destroying Arkivum appliance '${ARKIVUM_INSTANCE}' ..."
+    # Establish session
+    session_get
+    # Get the IP of the existing instance(s), if any
+    local -r instance_id="$(aws_ec2_get_id_for_instance_name "${ARKIVUM_INSTANCE}")"
+    # Destroy the instance(s)
+    # shellcheck disable=SC2001
+    for i_id in $(echo "${instance_id}" | sed 's/$/ /g') ; do
+        aws_ec2_terminate_instance "${i_id}"
+    done
+    # Destroy the security group
+    aws_sg_remove "${ARKIVUM_INSTANCE}"
+    # Remove keypair
+    aws_keypair_remove "${ARKIVUM_INSTANCE}" "${SSH_KEY_PATH}"
+    log_info "Arkivum appliance '${ARKIVUM_INSTANCE}' has been destroyed."
+}
+
+teardown_dockerhost()
+{
+    log_info "Destroying Docker host '${DOCKERHOST_INSTANCE}' ..."
+    # Establish session
+    session_get
+    # Get the IP of the existing instance, if any
+    local -r instance_id="$(aws_ec2_get_id_for_instance_name "${DOCKERHOST_INSTANCE}")"
+    if [ "${instance_id}" != "" ] ; then
+        # Destroy the containers and stop the dockerhost
+        destroy_containers
+        docker_machine_stop "${DOCKERHOST_INSTANCE}"
+    fi
+    # Remove the docker machine entirely - even if there is no instance running
+    docker_machine_remove "${DOCKERHOST_INSTANCE}"
+    log_info "Docker host '${DOCKERHOST_INSTANCE}' has been destroyed."
+}
+
+teardown_hosted_zones()
+{
+# Establish session
+    session_get
+    # Remove all records from the public zone.
+    aws_r53_remove_zone_records "${PUBLIC_HOSTED_ZONE}"
+    # Remove the public hosted zone. It should be empty after we have removed
+    # all other services.
+    aws_r53_remove_zone "${PUBLIC_HOSTED_ZONE}"
+    # Remove all records from the private zone.
+    aws_r53_remove_zone_records "${PRIVATE_HOSTED_ZONE}"
+    # Remove the private hosted zone. It should be empty after we have removed
+    # all other services.
+    aws_r53_remove_zone "${PRIVATE_HOSTED_ZONE}"
+}
+
+teardown_nfs_server()
+{
+    log_info "Destroying NFS server '${NFS_INSTANCE}' ..."
+    # Establish session
+    session_get
+    # Get the IP of the existing instance, if any
+    local -r instance_id=$(aws_ec2_get_id_for_instance_name "${NFS_INSTANCE}")
+    # Destroy the instance(s)
+    # shellcheck disable=SC2001
+    for i_id in $(echo "${instance_id}" | sed 's/$/ /g') ; do
+        aws_ec2_terminate_instance "${i_id}"
+    done
+    # Destroy the security group
+    aws_sg_remove "${NFS_INSTANCE}"
+    # Remove keypair
+    aws_keypair_remove "${NFS_INSTANCE}" "${SSH_KEY_PATH}"
+    if [ "${DESTROY_VOLUMES}" != "" ] ; then
+        # Destroy the EBS data volume
+        local -r volume_name="${NFS_INSTANCE}-data"
+        local -r volume_id="$(aws_ec2_get_id_for_volume_name "${volume_name}")"
+        if [ "${volume_id}" != "" ] ; then
+            log_info "Deleting volume '${volume_name}' ..."
+            aws ec2 delete-volume --volume-id "${volume_id}"
+            log_info "Deleted volume '${volume_name}'."
+        fi
+    fi
+    log_info "NFS server '${NFS_INSTANCE}' has been destroyed."
+}
+
+# Entrypoint ###################################################################
+
+main()
+{
+    log_info "RDSSARK Teardown Script starting..."
+    log_info "The following AWS parameters will be used:"
+    log_info "  MFA enabled: ${MFA_AUTH_ENABLED}"
+    log_info "  Region     : ${AWS_REGION}"
+    log_info "  VPC Id     : ${VPC_ID}"
+    log_info "  Subnet Id  : ${SUBNET_ID:-auto}"
+    log_info "The following instances will be torn down:"
+    if [ ! -z "${ARKIVUM_ENABLED}" ] ; then
+        log_info "  Arkivum appliance: ${ARKIVUM_INSTANCE}"
+    fi
+    log_info "  NFS server       : ${NFS_INSTANCE}"
+    log_info "  Docker host      : ${DOCKERHOST_INSTANCE}"
+    log_info "The following hosted zones will be removed:"
+    log_info "  Private: ${PRIVATE_HOSTED_ZONE}"
+    log_info "  Public : ${PUBLIC_HOSTED_ZONE}"
+    if [ "${DESTROY_VOLUMES}" != "" ] ; then
+        log_alert "DESTROY_VOLUMES IS SET - ALL DATA WILL BE DESTROYED!!!"
+        log_alert "Abort now using CTRL+C if you do not wish to do this!!"
+        sleep 20
+        log_alert "Timeout passed - this script will remove all data!"
+    fi
+    log_info ">>>>>> TEARING DOWN >>>>>"
+    # Tear down the docker host that runs Archivematica and NextCloud
+    teardown_dockerhost
+    # Tear down the NFS server used as shared storage
+    teardown_nfs_server
+    if [ ! -z "${ARKIVUM_ENABLED}" ] ; then
+        # Tear down the Arkivum appliance
+        teardown_arkivum
+    fi
+    # Tear down the hosted zones
+    teardown_hosted_zones
+    log_info "<<<<<< TEAR DOWN COMPLETE <<<<<"
+    log_info "Done."
+}
+
+main "$@"


### PR DESCRIPTION
**UPDATE: This has evolved over the past few months and so is more than the original pull request was aiming for. See my latest comment below for better description of the work/change that this introduces.**

I've added a `provision-and-deploy.sh` script that basically carries out all of the steps that were previously described in the README, but does them automatically. The only thing you have to do is authenticate with AWS (which the script helps with too).

The script attempts to:
1. Get an active AWS session to use, challenging the user and creating a new one if there isn't one, including MFA auth
1. Determine the status of the target EC2 instance for Docker Machine to use, creating (provisioning) one if it doesn't exist, or starting it if it is stopped.
1. Copy the required source files to the EC2 instance and running `make all SHIBBOLETH_CONFIG=archivematica` to deploy the services to the remote docker host.

Credentials from the standard `AWS_` environment variables are used where appropriate. Additional parameters are stored in `.machine-credentials`.

There are some configuration params that can't be guessed. These must be put into the `machine.conf`, which is based on the template `machine.conf.template`. This template must be copied, editied and renamed before use.

Once you have the template in place, just run `./provision-and-deploy.sh`, like the updated README says.

This is still a work in progress; it works for me but I haven't had chance to test it thoroughly. The intention was to make deploying to AWS extremely simple and repeatable.

This change builds on the changes in PR #26.