### PR TITLE
Compose: static ports minio and msgcreator

### DIFF
--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -20,7 +20,7 @@ services:
       - "${VOL_BASE}/dev/etc/minio:/root/.minio"
       - "${VOL_BASE}/dev/s3:/export"
     ports:
-      - "9000"
+      - "50500:9000"
     expose:
       - "9000"
 
@@ -282,4 +282,4 @@ services:
     volumes:
       - "${VOL_BASE}/../src/rdss-archivematica-msgcreator:/go/src/github.com/JiscRDSS/rdss-archivematica-msgcreator"
     ports:
-      - "8000"
+      - "50501:8000"


### PR DESCRIPTION
If you're testing this branch, run:

    $ docker-compose up -d --force-recreate minio rdss-archivematica-msgcreator

Only changes minio and msgcreator ports.

- minio: http://127.0.0.1:50500
- rdss-archivematica-msgcreator: http://127.0.0.1:50501