### PR TITLE
Problem: msgcreator is not accessible via https (443/tcp)

### DIFF
--- a/compose/am-shib/nginx/templates/am-shib.conf.tpl
+++ b/compose/am-shib/nginx/templates/am-shib.conf.tpl
@@ -68,6 +68,8 @@ server {
 		proxy_read_timeout 172800s;
 		proxy_pass $upstream_endpoint;
 	}
+
+	include /etc/nginx/incs/msgcreator.inc;
 }
 
 #

--- a/compose/dev/etc/nginx/conf.d/archivematica.conf
+++ b/compose/dev/etc/nginx/conf.d/archivematica.conf
@@ -12,6 +12,7 @@ server {
 		proxy_read_timeout 172800s;
 		proxy_pass $upstream_endpoint;
 	}
+	include /etc/nginx/incs/msgcreator.inc;
 }
 
 server {

--- a/compose/dev/etc/nginx/incs/msgcreator.inc
+++ b/compose/dev/etc/nginx/incs/msgcreator.inc
@@ -1,0 +1,6 @@
+location /msgcreator {
+	set $upstream_endpoint http://rdss-archivematica-msgcreator:8000/;
+
+	proxy_redirect off;
+	proxy_pass $upstream_endpoint;
+}

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -77,6 +77,7 @@ services:
     image: "nginx:stable-alpine"
     volumes:
       - "${VOL_BASE}/dev/etc/nginx/nginx.conf:/etc/nginx/nginx.conf:ro"
+      - "${VOL_BASE}/dev/etc/nginx/incs/:/etc/nginx/incs/:ro"
       - "${VOL_BASE}/dev/etc/nginx/conf.d/archivematica.conf:/etc/nginx/conf.d/archivematica.conf:ro"
       - "${VOL_BASE}/dev/etc/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro"
     expose:
@@ -276,10 +277,10 @@ services:
   rdss-archivematica-msgcreator:
     build:
       context: "../src/rdss-archivematica-msgcreator"
-    entrypoint: "go run main.go -addr=0.0.0.0:8000 -kinesis-endpoint=http://minikine:4567 -kinesis-stream=main -kinesis-region=eu-west-2 -s3-access-key=AKIAIOSFODNN7EXAMPLE -s3-secret-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY -s3-region=eu-west-2 -s3-endpoint=https://minio:9000"
+    entrypoint: "go run main.go -addr=0.0.0.0:8000 -prefix=/msgcreator -kinesis-endpoint=http://minikine:4567 -kinesis-stream=main -kinesis-region=eu-west-2 -s3-access-key=AKIAIOSFODNN7EXAMPLE -s3-secret-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY -s3-region=eu-west-2 -s3-endpoint=https://minio:9000"
     links:
       - "minikine"
     volumes:
       - "${VOL_BASE}/../src/rdss-archivematica-msgcreator:/go/src/github.com/JiscRDSS/rdss-archivematica-msgcreator"
-    ports:
-      - "50501:8000"
+    expose:
+      - "8000"


### PR DESCRIPTION
We want to make sure that we'll be able to access to msgcreator in our QA environment via the standard 443/tcp port as we expect non-standard ports to be blocked by institutional firewalls.

I've tested this without shib and it works. Now building am-shib to see if it works.