### PR TITLE
Compose: use named volumes for pipeline and storage service data

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -30,6 +30,12 @@ SS_GUNICORN_WORKERS=1
 AM_GUNICORN_ACCESSLOG=/dev/null
 SS_GUNICORN_ACCESSLOG=/dev/null
 
+# Volume names for 'external' named volume mounts used for sharing data
+# between Archivematica components and with other systems. Prefixes may be
+# either 'local_' or 'nfs_'.
+AM_PIPELINE_DATA_VOLUME=local_am-pipeline-data
+SS_DEFAULT_LOCATION_DATA_VOLUME=local_ss-default-location-data
+
 # The external port for the Archivematica Dashboard user interface.
 AM_DASHBOARD_EXTERNAL_PORT=443
 

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -5,9 +5,16 @@ COMPOSE_DIRS=dev
 
 BASE_DIR ?= ${CURDIR}
 
-SHIBBOLETH_IDP ?= local
+# Local mounted volume paths
+AM_PIPELINE_DATA ?= $(BASE_DIR)/vols/am-pipeline-data
+SS_DEFAULT_LOCATION_DATA ?= $(BASE_DIR)/../src
+
+# NFS mounted volume paths
+NFS_AM_PIPELINE_DATA ?= /am-pipeline-data
+NFS_SS_DEFAULT_LOCATION_DATA ?= /am-ss-default-location-data
 
 # Do we want to include any shibboleth services?
+SHIBBOLETH_IDP ?= local
 ifdef SHIBBOLETH_CONFIG
 	ifeq ("$(SHIBBOLETH_CONFIG)", "archivematica")
 		override COMPOSE_DIRS += am-shib
@@ -38,6 +45,18 @@ build clean destroy:
 config:
 	docker-compose config
 
+create-local-volumes:
+	docker volume create --opt type=none --opt o=bind \
+		--opt device=$(AM_PIPELINE_DATA) local_am-pipeline-data
+	docker volume create --opt type=none --opt o=bind \
+		--opt device=$(SS_DEFAULT_LOCATION_DATA) local_ss-default-location-data
+
+create-nfs-volumes:
+	docker volume create --opt type=nfs --opt o=addr=$(NFS_SERVER),rw \
+		--opt device=:$(NFS_AM_PIPELINE_DATA) nfs_am-pipeline-data
+	docker volume create --opt type=nfs --opt o=addr=$(NFS_SERVER),rw \
+		--opt device=:$(NFS_SS_DEFAULT_LOCATION_DATA) nfs_ss-default-location-data
+
 list:
 	docker-compose ps
 
@@ -58,4 +77,4 @@ watch-idp:
 watch-nginx:
 	docker-compose logs -f nginx
 
-.PHONY: all bootstrap build clean create-secrets config destroy list watch watch-idp watch-nginx up
+.PHONY: all bootstrap build clean create-local-volumes create-nfs-volumes create-secrets config destroy list watch watch-idp watch-nginx up

--- a/compose/README.md
+++ b/compose/README.md
@@ -11,6 +11,36 @@ In the above, the main Archivematica services are highlighted in orange. The ser
 
 Some of these containers are required for local development only. In a production deployment, the `dynalite`, `minikine` and `minio` containers would be replaced with connections to actual DynamoDB, Kinesis and S3 services in an AWS environment. Similarly, if the Shibboleth SP in the `nginx` container is configured to use an external IdP then the `idp` and `ldap` containers would become unnecessary.
 
+External Volumes
+-----------------
+
+To allow Archivematica to interact and share data with other systems in the environment, some volumes are marked as `external`. These must be created prior to starting the docker containers.
+
+| Volume | Description |
+|---|---|
+| `archivematica_pipeline_data` | Used to store data shared across Archivematica components. Also used by external systems to input data to Archivematica, and to retrieve outputs from Archivematica (`www/AIPsStore` and `www/DIPsStore`). |
+| `archivematica_storage_service_default_location_data` | Used to provide data storage for the Storage Service. Making this external allows other systems to input data into Archivematica. |
+
+To create volumes for directories on the local machine, i.e. in a development environment, use
+
+	make create-local-volumes
+
+To create volumes for directories on a NFS server, i.e. in a QA or production environment, use
+
+	make create-nfs-volumes NFS_SERVER=192.168.0.1
+
+The `NFS_SERVER` is required - there's no way to guess it or use a sensible default.
+
+The parameters for the volumes created are as follows, and may be overridden via Makefile arguments:
+
+| Parameter | Description | Default |
+|---|---|---|
+| `AM_PIPELINE_DATA` | The *local* path on the docker host to use for Archivematica's `sharedDirectory` pipeline data. | `$(BASE_DIR)/vols/am-pipeline-data`
+| `SS_DEFAULT_LOCATION_DATA` | The *local* path on the docker host to use for Archivematica's default location in the Storage Service. | `$(BASE_DIR)/../src` |
+| `NFS_SERVER` | The IP address of the NFS server to use for the NFS volumes. This value is required. | N/A |
+| `NFS_AM_PIPELINE_DATA` | The *remote* path on the NFS server to use for Archivematica's `sharedDirectory` pipeline data. | `/am-pipeline-data` |
+| `NFS_SS_DEFAULT_LOCATION_DATA` | The *remote* path on the NFS server to use for Archivematica's default location in the Storage Service. |
+
 Service Sets
 -------------
 
@@ -69,6 +99,8 @@ Details of the services deployed for each service set are in the README for that
 
 Building
 ---------
+
+*Before building, make sure you create the required volumes (see above)*
 
 To build all containers required to bring up a development version of Archivematica, use
 
@@ -151,9 +183,11 @@ The following environment variables are supported by this build.
 
 | Variable | Description |
 |---|---|
+| `AM_PIPELINE_DATA_VOLUME` | The named Docker volume to use for Archivematica pipeline data. This is an external volume that is expected to be created prior to the containers being instantiated (see [External Volumes](#externalvolumes) above). Valid values are `local_am-pipeline-data` (default) or `nfs_am-pipeline-data`. |
 | `DOMAIN_NAME` | The domain name to use when configuring Shibboleth. |
 | `SHIBBOLETH_CONFIG` | The Shibboleth profile to use. Currently only `archivematica` is supported. Default is undefined, causing no Shibboleth support to be enabled. |
 | `SHIBBOLETH_IDP` | The shibboleth IdP profile to use. Currently only `local` is supported, which is the default if `SHIBBOLETH_CONFIG` is set. Setting to another value will prevent the local Shibboleth IdP ([shib-local](shib-local)) from being included. |
+| `SS_DEFAULT_LOCATION_DATA_VOLUME` | The named Docker volume to use for Archivematica Storage Service default location data. This is an external volume that is expected to be created prior to the containers being instantiated (see [External Volumes](#externalvolumes) above). Valid values are `local_ss-default-location-data` (default) or `nfs_ss-default-location-data`. |
 | `VOL_BASE` | The path to use as the base for specifying volume paths in `docker-compose` configurations. Default is `'.'`, which gets correctly interpreted when build machine is the same as docker host. When deploying to a remote docker host (e.g. via `docker-machine`), this must be set to the path of the equivalent base path on the docker host, e.g. `/home/ubuntu/rdss-archivematica/compose` if using a standard Ubuntu AMI on EC2). |
 
 See also the individual [idp](shib-local/idp), [ldap](shib-local/ldap) and [nginx](am-shib/nginx) services for additional environment variables used by those specific services.

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -3,10 +3,25 @@ version: "2"
 
 volumes:
 
-  mysql_data:
+  # Internal Named Volumes
+  # These are not accessible outside of the docker host and are maintained by
+  # Docker.
   elasticsearch_data:
-  archivematica_pipeline_data:
   archivematica_storage_service_staging_data:
+  mysql_data:
+
+  # External Named Volumes
+  # These are intended to be accessible beyond the docker host (e.g. via NFS).
+  # They use bind mounts to mount a specific "local" directory on the docker
+  # host - the expectation being that these directories are actually mounted
+  # filesystems from elsewhere.
+  archivematica_pipeline_data:
+    external:
+      name: ${AM_PIPELINE_DATA_VOLUME}
+  archivematica_storage_service_default_location_data:
+    external:
+      name: ${SS_DEFAULT_LOCATION_DATA_VOLUME}
+
 
 services:
 
@@ -207,9 +222,10 @@ services:
       SS_DB_URL: "mysql://archivematica:demo@mysql/SS"
     volumes:
       - "${VOL_BASE}/../src/archivematica-storage-service/:/src/"
-      - "${VOL_BASE}/../src/archivematica-sampledata/:/home/archivematica-sampledata/"
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"
       - "archivematica_storage_service_staging_data:/var/archivematica/storage_service:rw"
+      # Transfer Sources - add more if additional locations are defined
+      - "archivematica_storage_service_default_location_data:/home:rw"
     expose:
       - "8000"
     links:


### PR DESCRIPTION
This addresses issue #35.

I've changed the definition of the `archivematica_pipeline_data` and `archivematica_storage_service_data` volumes so that they are now external. This means that `docker-compose` will not attempt to create them for us, we have to create them ourselves using [docker volume](https://docs.docker.com/engine/reference/commandline/volume_create/). However the new `make create-local-volumes` and `make create-nfs-volumes` targets, which need to be run before `make all` do this for us.

As the names suggest, I've made it so that the external volumes can be either 'local' (via a bind mount) or 'remote', using NFS. This should facilitate use in both dev and production environments.

I've updated the readme with instructions on how to configure these volumes.

TL;DR here's the make commands:
```make create-nfs-volumes NFS_SERVER=172.18.6.2
AM_PIPELINE_DATA_VOLUME=nfs_am-pipeline-data \
SS_DEFAULT_LOCATION_DATA=nfs_ss-default-location-data \
    make all SHIBBOLETH_CONFIG=archivematica
```

By storing this data on NFS we can access the AIPs and DIPs output by Archivematica, as well as Archivematica accessing submitted input data for transfer, in a (fairly) easy configurable way.