### PR TITLE
Compose: fix IdP metadata to correctly use env vars in configuration

### DIFF
--- a/compose/shib-local/Makefile
+++ b/compose/shib-local/Makefile
@@ -13,6 +13,8 @@ DOMAIN_NAME ?= example.ac.uk
 
 IDP_EXTERNAL_PORT ?= 6443
 
+NGINX_HOSTNAME ?= archivematica.$(DOMAIN_NAME)
+
 all: destroy init-ca build create-secrets up bootstrap list
 
 build: build-idp
@@ -31,6 +33,7 @@ build-idp:
 		--volume "$(VOL_BASE)/shib-local/etc/idp/:/src/etc/:ro" \
 		--volume "$(VOL_BASE)/shib-local/build/idp/:/build" \
 		--workdir "/src" \
+		-e NGINX_HOSTNAME=$(NGINX_HOSTNAME) \
 		python:2-alpine \
 		python idp-metadata-providers.py /src/etc/service-providers.json > \
 			"$(BASE_DIR)/build/idp/metadata-providers.xml"

--- a/compose/shib-local/etc/idp/service-providers.json
+++ b/compose/shib-local/etc/idp/service-providers.json
@@ -1,8 +1,8 @@
 {
   "am-dashboard" : {
-    "metadata": "https://archivematica.${DOMAIN_NAME}:${AM_DASHBOARD_EXTERNAL_PORT}/Shibboleth.sso/metadata"
+    "metadata": "https://${NGINX_HOSTNAME}:${AM_DASHBOARD_EXTERNAL_PORT}/Shibboleth.sso/metadata"
   },
   "am-storage-service" : {
-    "metadata": "https://archivematica.${DOMAIN_NAME}:${AM_STORAGE_SERVICE_EXTERNAL_PORT}/Shibboleth.sso/metadata"
+    "metadata": "https://${NGINX_HOSTNAME}:${AM_STORAGE_SERVICE_EXTERNAL_PORT}/Shibboleth.sso/metadata"
   }
 }

--- a/compose/shib-local/idp-metadata-providers.py
+++ b/compose/shib-local/idp-metadata-providers.py
@@ -51,7 +51,7 @@ with open(sp_conf_file, 'r') as f:
    sp_conf = json.load(f)
    for sp in sp_conf:
       metadata_url = sp_conf[sp]['metadata'].replace(
-         '${DOMAIN_NAME}', os.getenv('DOMAIN_NAME', 'example.ac.uk')).replace(
+         '${NGINX_HOSTNAME}', os.getenv('NGINX_HOSTNAME', 'archivematica.example.ac.uk')).replace(
          '${AM_DASHBOARD_EXTERNAL_PORT}', os.getenv('AM_DASHBOARD_EXTERNAL_PORT', '443')).replace(
          '${AM_STORAGE_SERVICE_EXTERNAL_PORT}', os.getenv('AM_STORAGE_SERVICE_EXTERNAL_PORT', '8443'))
       print ("""

--- a/compose/shib-local/idp/README.md
+++ b/compose/shib-local/idp/README.md
@@ -75,6 +75,7 @@ The following environment variables are used by this service:
 | AM_STORAGE_SERVICE_EXTERNAL_PORT | The external port that the Archivematica Storage Service should be exposed on. Default is 8443 |
 | DOMAIN_NAME | The domain name to use for this IdP. This becomes the Shibboleth "scope", i.e. the domain that is 'managed' by this IdP. Default value is `example.ac.uk` |
 | IDP_EXTERNAL_PORT | The external port that the IdP is exposed on. Default is 6443. |
+| NGINX_HOSTNAME | The hostname of the `nginx` service, which is expected to be proxying the Archivematica Dashboard and Storage Service. Default value is `archivematica.example.ac.uk`. |
 
 UI Customization
 -----------------


### PR DESCRIPTION
Changed to use NGINX_HOSTNAME instead of DOMAIN_NAME because this is actually
more accurate in terms of our intent.

This fixes #33.