### PR TITLE
Compose: removed use of nfs named volumes because they're broken

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -30,12 +30,6 @@ SS_GUNICORN_WORKERS=1
 AM_GUNICORN_ACCESSLOG=/dev/null
 SS_GUNICORN_ACCESSLOG=/dev/null
 
-# Volume names for 'external' named volume mounts used for sharing data
-# between Archivematica components and with other systems. Prefixes may be
-# either 'local_' or 'nfs_'.
-AM_PIPELINE_DATA_VOLUME=local_am-pipeline-data
-SS_DEFAULT_LOCATION_DATA_VOLUME=local_ss-default-location-data
-
 # The external port for the Archivematica Dashboard user interface.
 AM_DASHBOARD_EXTERNAL_PORT=443
 

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -5,13 +5,9 @@ COMPOSE_DIRS=dev
 
 BASE_DIR ?= ${CURDIR}
 
-# Local mounted volume paths
-AM_PIPELINE_DATA ?= $(BASE_DIR)/vols/am-pipeline-data
-SS_DEFAULT_LOCATION_DATA ?= $(BASE_DIR)/../src
-
-# NFS mounted volume paths
-NFS_AM_PIPELINE_DATA ?= /am-pipeline-data
-NFS_SS_DEFAULT_LOCATION_DATA ?= /am-ss-default-location-data
+# Paths for Docker named volumes
+AM_PIPELINE_DATA ?= /tmp/am-pipeline-data
+SS_LOCATION_DATA ?= $(BASE_DIR)/../src
 
 # Do we want to include any shibboleth services?
 SHIBBOLETH_IDP ?= local
@@ -45,17 +41,13 @@ build clean destroy:
 config:
 	docker-compose config
 
-create-local-volumes:
+create-volumes:
+	mkdir -p ${AM_PIPELINE_DATA}
 	docker volume create --opt type=none --opt o=bind \
-		--opt device=$(AM_PIPELINE_DATA) local_am-pipeline-data
+		--opt device=$(AM_PIPELINE_DATA) rdss_am-pipeline-data
+	mkdir -p ${SS_LOCATION_DATA}
 	docker volume create --opt type=none --opt o=bind \
-		--opt device=$(SS_DEFAULT_LOCATION_DATA) local_ss-default-location-data
-
-create-nfs-volumes:
-	docker volume create --opt type=nfs --opt o=addr=$(NFS_SERVER),rw \
-		--opt device=:$(NFS_AM_PIPELINE_DATA) nfs_am-pipeline-data
-	docker volume create --opt type=nfs --opt o=addr=$(NFS_SERVER),rw \
-		--opt device=:$(NFS_SS_DEFAULT_LOCATION_DATA) nfs_ss-default-location-data
+		--opt device=$(SS_LOCATION_DATA) rdss_am-ss-location-data
 
 list:
 	docker-compose ps
@@ -77,4 +69,4 @@ watch-idp:
 watch-nginx:
 	docker-compose logs -f nginx
 
-.PHONY: all bootstrap build clean create-local-volumes create-nfs-volumes create-secrets config destroy list watch watch-idp watch-nginx up
+.PHONY: all bootstrap build clean create-volumes create-secrets config destroy list watch watch-idp watch-nginx up

--- a/compose/README.md
+++ b/compose/README.md
@@ -21,25 +21,22 @@ To allow Archivematica to interact and share data with other systems in the envi
 | `archivematica_pipeline_data` | Used to store data shared across Archivematica components. Also used by external systems to input data to Archivematica, and to retrieve outputs from Archivematica (`www/AIPsStore` and `www/DIPsStore`). |
 | `archivematica_storage_service_default_location_data` | Used to provide data storage for the Storage Service. Making this external allows other systems to input data into Archivematica. |
 
-To create volumes for directories on the local machine, i.e. in a development environment, use
+To create volumes for directories on the local machine use
 
-	make create-local-volumes
-
-To create volumes for directories on a NFS server, i.e. in a QA or production environment, use
-
-	make create-nfs-volumes NFS_SERVER=192.168.0.1
-
-The `NFS_SERVER` is required - there's no way to guess it or use a sensible default.
+	make create-volumes
 
 The parameters for the volumes created are as follows, and may be overridden via Makefile arguments:
 
 | Parameter | Description | Default |
 |---|---|---|
-| `AM_PIPELINE_DATA` | The *local* path on the docker host to use for Archivematica's `sharedDirectory` pipeline data. | `$(BASE_DIR)/vols/am-pipeline-data`
-| `SS_DEFAULT_LOCATION_DATA` | The *local* path on the docker host to use for Archivematica's default location in the Storage Service. | `$(BASE_DIR)/../src` |
-| `NFS_SERVER` | The IP address of the NFS server to use for the NFS volumes. This value is required. | N/A |
-| `NFS_AM_PIPELINE_DATA` | The *remote* path on the NFS server to use for Archivematica's `sharedDirectory` pipeline data. | `/am-pipeline-data` |
-| `NFS_SS_DEFAULT_LOCATION_DATA` | The *remote* path on the NFS server to use for Archivematica's default location in the Storage Service. |
+| `AM_PIPELINE_DATA` | The path on the docker host to use for Archivematica's `sharedDirectory` pipeline data. | `/tmp/am-pipeline-data`
+| `SS_LOCATION_DATA` | The path on the docker host to use for Archivematica's default location in the Storage Service. | `$(BASE_DIR)/../src` |
+
+For example, to use NFS mounts instead of the default locations
+
+	make create-volumes \
+		AM_PIPELINE_DATA=/mnt/nfs/am-pipeline-data \
+		SS_LOCATION_DATA=/mnt/nfs/am-ss-default-location-data
 
 Service Sets
 -------------
@@ -183,11 +180,9 @@ The following environment variables are supported by this build.
 
 | Variable | Description |
 |---|---|
-| `AM_PIPELINE_DATA_VOLUME` | The named Docker volume to use for Archivematica pipeline data. This is an external volume that is expected to be created prior to the containers being instantiated (see [External Volumes](#externalvolumes) above). Valid values are `local_am-pipeline-data` (default) or `nfs_am-pipeline-data`. |
 | `DOMAIN_NAME` | The domain name to use when configuring Shibboleth. |
 | `SHIBBOLETH_CONFIG` | The Shibboleth profile to use. Currently only `archivematica` is supported. Default is undefined, causing no Shibboleth support to be enabled. |
 | `SHIBBOLETH_IDP` | The shibboleth IdP profile to use. Currently only `local` is supported, which is the default if `SHIBBOLETH_CONFIG` is set. Setting to another value will prevent the local Shibboleth IdP ([shib-local](shib-local)) from being included. |
-| `SS_DEFAULT_LOCATION_DATA_VOLUME` | The named Docker volume to use for Archivematica Storage Service default location data. This is an external volume that is expected to be created prior to the containers being instantiated (see [External Volumes](#externalvolumes) above). Valid values are `local_ss-default-location-data` (default) or `nfs_ss-default-location-data`. |
 | `VOL_BASE` | The path to use as the base for specifying volume paths in `docker-compose` configurations. Default is `'.'`, which gets correctly interpreted when build machine is the same as docker host. When deploying to a remote docker host (e.g. via `docker-machine`), this must be set to the path of the equivalent base path on the docker host, e.g. `/home/ubuntu/rdss-archivematica/compose` if using a standard Ubuntu AMI on EC2). |
 
 See also the individual [idp](shib-local/idp), [ldap](shib-local/ldap) and [nginx](am-shib/nginx) services for additional environment variables used by those specific services.

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -17,10 +17,10 @@ volumes:
   # filesystems from elsewhere.
   archivematica_pipeline_data:
     external:
-      name: ${AM_PIPELINE_DATA_VOLUME}
-  archivematica_storage_service_default_location_data:
+      name: "rdss_am-pipeline-data"
+  archivematica_storage_service_location_data:
     external:
-      name: ${SS_DEFAULT_LOCATION_DATA_VOLUME}
+      name: "rdss_am-ss-location-data"
 
 
 services:
@@ -225,8 +225,7 @@ services:
       - "${VOL_BASE}/../src/archivematica-storage-service/:/src/"
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"
       - "archivematica_storage_service_staging_data:/var/archivematica/storage_service:rw"
-      # Transfer Sources - add more if additional locations are defined
-      - "archivematica_storage_service_default_location_data:/home:rw"
+      - "archivematica_storage_service_location_data:/home:rw"
     expose:
       - "8000"
     links:


### PR DESCRIPTION
When we tried to actually use the [docker volumes for NFS](https://docs.docker.com/engine/reference/commandline/volume_create/#driver-specific-options) we added in PR #36 they wouldn't connect. 

I've therefore replaced them with local bind mounts, in the expectation that 'local' folders
can actually be mounted NFS volumes, thereby delagating to the OS rather than doing it
in Docker. This is much simpler anyway.

This is another fix for #35.