### PR TITLE
Compose: pin openldap image to use debian 8 instead of debian 9

### DIFF
--- a/compose/shib-local/ldap/Dockerfile
+++ b/compose/shib-local/ldap/Dockerfile
@@ -1,4 +1,5 @@
-FROM osixia/openldap
+# Pin against last release that used debian 8, to avoid incompatibility with debian 9
+FROM osixia/openldap@sha256:443571790e7db8dd7072d31003089fbec1acf490340173c34a39cd6f4aa345e5
 
 MAINTAINER Arkivum Limited
 


### PR DESCRIPTION
Ideally we should update to use debian 9, but that is lower priority than
getting the image working again.

Fixes issue #60.