### PR TITLE
Compose: update idp image to avoid hard coded Zulu version

### DIFF
--- a/compose/shib-local/idp/bootstrap.sh
+++ b/compose/shib-local/idp/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ZULU_HOME=/opt/zulu8.20.0.5-jdk8.0.121-linux_x64
+JRE_HOME=/opt/jre-home
 
 if [ -s /usr/share/pki/ca-trust-source/anchors/${DOMAIN_NAME}-ca.crt ] ; then
 	exit
@@ -9,9 +9,9 @@ fi
 # Copy CA cert into trusted location and update Linux trusted certs registry
 cp -p /secrets/${DOMAIN_NAME}-ca.crt /usr/share/pki/ca-trust-source/anchors/ && update-ca-trust
 # Also update JRE trusted certs so Tomcat trusts it too
-chmod +x ${ZULU_HOME}/bin/keytool
+chmod +x ${JRE_HOME}/bin/keytool
 sleep 5
-${ZULU_HOME}/bin/keytool -import -noprompt -trustcacerts -alias ${DOMAIN_NAME} \
+${JRE_HOME}/bin/keytool -import -noprompt -trustcacerts -alias ${DOMAIN_NAME} \
 	-file /secrets/${DOMAIN_NAME}-ca.crt \
-	-keystore  /opt/zulu8.20.0.5-jdk8.0.121-linux_x64/jre/lib/security/cacerts \
+	-keystore  ${JRE_HOME}/lib/security/cacerts \
 	-storepass changeit


### PR DESCRIPTION
The /opt/jre-home symlink is already present in the base image, so just reusing that.

This fixes #61.