### PR TITLE
Update channel adapter to v0.1.2

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -25,7 +25,7 @@
         dest: "./src/rdss-archivematica-automation-tools"
       - name: "RDSS Archivematica Channel Adapter"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
-        version: "master"
+        version: "v0.1.2"
         dest: "./src/rdss-archivematica-channel-adapter"
       - name: "RDSS Arkivum NextCloud"
         repo: "https://github.com/JiscRDSS/rdss-arkivum-nextcloud"


### PR DESCRIPTION
We're working on a bigger update of the channel adapter incorporating features like the local data repository or better schema support - this will eventually reach `master` so I thought it's probably a good idea to pin this repo to the latest release available: `v0.1.2`.