### PR TITLE
Problem: Compose bootstrap fails to set up pipeline in SS

### DIFF
--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -35,7 +35,8 @@ bootstrap-storage-service:
 					--username="test" \
 					--password="test" \
 					--email="test@test.com" \
-					--api-key="test"
+					--api-key="test" \
+					--superuser
 
 bootstrap-dashboard:
 	# Wait for services to start properly to avoid race/timing problems


### PR DESCRIPTION
The most recent version of the create_user command in SS needs an extra flag
`--superuser` to have the user created with the superuser mode. This is
required in our Compose environment because we use this user to set up the
pipeline.