### PR TITLE
Add playbook for supporting/QA docker images

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -1,9 +1,13 @@
 ---
 
 #
+# Builds core RDSS Archivematica images intended for production deployment and
+# publishes them to the given Docker registry.
+#
 # Usage:
 #
-#     $ ansible-playbook publish-images-playbook.yml --extra-vars="registry=aws_account_id.dkr.ecr.region.amazonaws.com/"
+#     $ ansible-playbook publish-images-playbook.yml \
+#           --extra-vars="registry=aws_account_id.dkr.ecr.region.amazonaws.com/"
 #
 
 - hosts: "localhost"

--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -1,0 +1,73 @@
+---
+
+#
+# Builds supporting RDSS Archivematica images used for QA and publishes them to
+# the given Docker registry.
+#
+# Usage:
+#
+#     $ ansible-playbook publish-qa-images-playbook.yml \
+#           --extra-vars="registry=aws_account_id.dkr.ecr.region.amazonaws.com/"
+#
+
+- hosts: "localhost"
+  connection: "local"
+
+  vars:
+    repos:
+      - name: "RDSS Archivematica Channel Adapter"
+        repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
+        version: "v0.2.4"
+        dest: "./src/rdss-archivematica-channel-adapter"
+      - name: "RDSS Archivematica MsgCreator"
+        repo: "https://github.com/JiscRDSS/rdss-archivematica-msgcreator"
+        version: "master"
+        dest: "./src/rdss-archivematica-msgcreator"
+    images:
+      - name: "{{ registry }}rdss-archivematica-msgcreator"
+        dockerfile: "Dockerfile"
+        path: "./src/rdss-archivematica-msgcreator/"
+        tag: "latest"
+      - name: "{{ registry }}dynalite"
+        path: "./src/rdss-archivematica-channel-adapter/hack/minikine"
+        dockerfile: "dynalite.Dockerfile"
+        tag: "latest"
+      - name: "{{ registry }}minikine"
+        path: "./src/rdss-archivematica-channel-adapter/hack/minikine"
+        dockerfile: "minikine.Dockerfile"
+        tag: "latest"
+
+
+  tasks:
+
+    - name: "Ensure that the variable registry is defined"
+      fail:
+        msg: "Variable registry is undefined"
+      when: "registry is not defined"
+
+    - name: "Install playbook dependencies"
+      pip:
+        name: "{{ item }}"
+        extra_args: "--user"
+      with_items:
+        - "setuptools"
+        - "docker-py"
+
+    - name: "Clone repositories"
+      git:
+        accept_hostkey: "yes"
+        repo: "{{ item.repo }}"
+        dest: "{{ item.dest }}"
+        version: "{{ item.version }}"
+      with_items: "{{ repos }}"
+
+    - name: "Build and publish images"
+      docker_image:
+        name: "{{ item.name }}"
+        tag: "{{ item.tag }}"
+        path: "{{ item.path }}"
+        dockerfile: "{{ item.dockerfile }}"
+        push: "yes"
+        state: "present"
+        force: "yes"
+      with_items: "{{ images }}"


### PR DESCRIPTION
The images we release to Jisc are built by the existing `publish-images-playbook.yml` Ansible playbook. However, this does not include the additional images we require in our own QA environment, such as MsgCreator and the DynamoDB, Kinesis and S3 mocks, Dynalite, Kinelite and Minio.

This pull request adds another playbook to build these in the same fashion as the main images. This will not be used by Jisc, but will be used by us internally for dev and QA purposes.

The images it builds are based on those that are required for the 'dev' Docker Compose configuration. It does not currently include those images required for our local Shibboleth services.

As we move to semver we can pin down the `version` for the repos and images defined in the playbook from branch names to tags, as has already been done for the Channel Adapter service.