### PR TITLE
Compose: update minio config

### DIFF
--- a/compose/dev/.gitignore
+++ b/compose/dev/.gitignore
@@ -1,1 +1,2 @@
 /s3/.minio.sys/
+/etc/minio/config.json.old

--- a/compose/dev/etc/minio/config.json
+++ b/compose/dev/etc/minio/config.json
@@ -1,5 +1,5 @@
 {
-	"version": "18",
+	"version": "19",
 	"credential": {
 		"accessKey": "AKIAIOSFODNN7EXAMPLE",
 		"secretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
@@ -105,6 +105,17 @@
 				"user": "",
 				"password": "",
 				"database": ""
+			}
+		},
+		"mqtt": {
+			"1": {
+				"enable": false,
+				"broker": "",
+				"topic": "",
+				"qos": 0,
+				"clientId": "",
+				"username": "",
+				"password": ""
 			}
 		}
 	}


### PR DESCRIPTION
minio keeps producing a new version of the configuration file and this pr just commits it so it doesn't show up in the git unstated area as a modified file which is annoying. It also ignores the .old version which we don't need since we're using git to track changes anyways. This PR also adds /src/rdss-archivematica-automation-tools to gitignore.