### PR TITLE
Bump channel adapter to v0.2.5

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -29,7 +29,7 @@
         dest: "./src/rdss-archivematica-automation-tools"
       - name: "RDSS Archivematica Channel Adapter"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
-        version: "v0.2.4"
+        version: "v0.2.5"
         dest: "./src/rdss-archivematica-channel-adapter"
       - name: "RDSS Arkivum NextCloud"
         repo: "https://github.com/JiscRDSS/rdss-arkivum-nextcloud"

--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -17,7 +17,7 @@
     repos:
       - name: "RDSS Archivematica Channel Adapter"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
-        version: "v0.2.4"
+        version: "v0.2.5"
         dest: "./src/rdss-archivematica-channel-adapter"
       - name: "RDSS Archivematica MsgCreator"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-msgcreator"


### PR DESCRIPTION
The new version of the channel adapter includes exponential back-off retry in the Archivematica client.