### PR TITLE
Added configurable my.cnf file

### DIFF
--- a/compose/dev/etc/mysql/my.cnf
+++ b/compose/dev/etc/mysql/my.cnf
@@ -1,0 +1,129 @@
+﻿#
+# The MySQL database server configuration file.
+#
+# You can copy this to one of:
+# - "/etc/mysql/my.cnf" to set global options,
+# - "~/.my.cnf" to set user-specific options.
+# 
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+# This will be passed to all mysql clients
+# It has been reported that passwords should be enclosed with ticks/quotes
+# escpecially if they contain "#" chars...
+# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
+[client]
+port = 3306
+socket = /var/run/mysqld/mysqld.sock
+
+# Here is entries for some specific programs
+# The following values assume you have at least 32M ram
+
+# This was formally known as [safe_mysqld]. Both versions are currently parsed.
+[mysqld_safe]
+socket = /var/run/mysqld/mysqld.sock
+nice = 0
+
+[mysqld]
+#
+# * Basic Settings
+#
+#user = mysql
+pid-file = /var/run/mysqld/mysqld.pid
+socket = /var/run/mysqld/mysqld.sock
+port = 3306
+basedir = /usr
+datadir = /var/lib/mysql
+tmpdir = /tmp
+lc-messages-dir = /usr/share/mysql
+skip-external-locking
+#
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure.
+#bind-address = 127.0.0.1
+#
+# * Fine Tuning
+#
+innodb_log_file_size = 1G
+key_buffer = 16M
+max_allowed_packet = 64M
+thread_stack = 192K
+thread_cache_size = 8
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched
+myisam-recover = BACKUP
+#max_connections = 100
+#table_cache = 64
+#thread_concurrency = 10
+#
+# * Query Cache Configuration
+#
+query_cache_limit = 1M
+query_cache_size = 16M
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# As of 5.1 you can enable the log at runtime!
+#general_log_file = /var/log/mysql/mysql.log
+#general_log = 1
+#
+# Error log - should be very few entries.
+#
+#log_error = /var/log/mysql/error.log
+#
+# Here you can see queries with especially long duration
+#slow_query_log_file = /var/log/mysql/mysql-slow.log
+#slow_query_log = 1
+#long_query_time = 2
+#log_queries_not_using_indexes
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+#server-id = 1
+#log_bin = /var/log/mysql/mysql-bin.log
+expire_logs_days = 10
+max_binlog_size = 100M
+#binlog_do_db = include_database_name
+#binlog_ignore_db = include_database_name
+#
+# * InnoDB
+#
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+#
+# * Security Features
+#
+# Read the manual, too, if you want chroot!
+# chroot = /var/lib/mysql/
+#
+# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
+#
+# ssl-ca = /etc/mysql/cacert.pem
+# ssl-cert = /etc/mysql/server-cert.pem
+# ssl-key = /etc/mysql/server-key.pem
+
+
+
+[mysqldump]
+quick
+quote-names
+max_allowed_packet = 64M
+
+[mysql]
+#no-auto-rehash	# faster start of mysql but no tab completition
+
+[isamchk]
+key_buffer = 16M
+
+#
+# * IMPORTANT: Additional settings that can override those from this file!
+#   The files must end with '.cnf', otherwise they'll be ignored.
+#
+!includedir /etc/mysql/conf.d/

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -47,6 +47,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: "12345"
     volumes:
+      - "${VOL_BASE}/dev/etc/mysql/my.cnf:/etc/mysql/my.cnf:ro"
       - "mysql_data:/var/lib/mysql"
     expose:
       - "3306"


### PR DESCRIPTION
This config file has been set to support large transfer (more than 20GB). It is based on the default config file of the percona 5.5 docker official repository.

Changes added to the default config file:

a) innodb_log_file_size = 1G

	This will increase the redo log size to 2G (using 2 files).

b) max_allowed_packet = 64 MB

	This change allows large insert MySQL queries. For example, at the end
    of the sanitize step.

This closes #84 and allows the configuration of the MySQL server before and after the deployment.