### PR TITLE
compose: fix my.cnf typo

### DIFF
--- a/compose/dev/etc/mysql/my.cnf
+++ b/compose/dev/etc/mysql/my.cnf
@@ -1,4 +1,4 @@
-﻿#
+#
 # The MySQL database server configuration file.
 #
 # You can copy this to one of:


### PR DESCRIPTION
It closes #96.

After running dos2unix on my.cnf file this strange character in the first line has gone:
```
diff --git a/compose/dev/etc/mysql/my.cnf b/compose/dev/etc/mysql/my.cnf
index e6c9ad0..74efc90 100644
--- a/compose/dev/etc/mysql/my.cnf
+++ b/compose/dev/etc/mysql/my.cnf
@@ -1,4 +1,4 @@
-<U+FEFF>#
+#
 # The MySQL database server configuration file.
 #
 # You can copy this to one of:
```