### PR TITLE
Configure pipeline URL into SS config

### DIFF
--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -238,6 +238,7 @@ services:
       SS_GUNICORN_RELOAD: "${SS_GUNICORN_RELOAD}"
       SS_GUNICORN_RELOAD_ENGINE: "${SS_GUNICORN_RELOAD_ENGINE}"
       SS_GUNICORN_WORKERS: "${SS_GUNICORN_WORKERS}"
+      SS_PIPELINE_REMOTE_NAME: "http://archivematica-dashboard:8000/"
       DJANGO_SECRET_KEY: "12345"
       DJANGO_SETTINGS_MODULE: "storage_service.settings.local"
       DJANGO_ALLOWED_HOSTS: "*"


### PR DESCRIPTION
This is part of the fix for https://github.com/JiscRDSS/rdss-archivematica/issues/63 (see also https://github.com/artefactual/archivematica-storage-service/issues/236)

Here we set an environment variable for the address that Storage Service needs to use to contact Dashboard.

See also https://github.com/JiscRDSS/archivematica-storage-service/pull/22