### PR TITLE
Add specific version tags to docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,14 @@
 language: bash
 
 install:
+  # Install yamllint for testing YAML files (including Ansible)
+  - pip install --user yamllint
   # Install ansible-lint for testing Ansible scripts
   - pip install --user ansible-lint
 
 script:
   # Validate our Ansible playbooks
+  - python -myamllint -f parsable *-playbook.yml
   - ansible-lint -p *-playbook.yml
   # TODO Add additional validation/build steps here
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@
 # This project is a mix of languages; default to bash for now
 language: bash
 
+install:
+  # Install ansible-lint for testing Ansible scripts
+  - pip install --user ansible-lint
+
 script:
-  # TODO Add validation/build steps here
+  # Validate our Ansible playbooks
+  - ansible-lint -p *-playbook.yml
+  # TODO Add additional validation/build steps here
 
 notifications:
   email: false

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  line-length:
+    level: warning
+

--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -90,28 +90,40 @@
         repo: "{{ item.repo }}"
         dest: "{{ item.dest }}"
         version: "{{ item.version }}"
+      register: "git_clone"
       with_items: "{{ projects }}"
 
     - name: "Prepare source"
       make:
-        chdir: "{{ item.dest }}"
-        target: "{{ item.make_target}}"
-      when: "item.make_target is defined"
-      with_items: "{{ projects }}"
+        chdir: "{{ item.item.dest }}"
+        target: "{{ item.item.make_target}}"
+      when: item.changed and item.item.make_target is defined
+      with_items: "{{ git_clone.results }}"
+      tags:
+        # Ignore false ANSIBLE0016 claiming this task should be a handler
+        - skip_ansible_lint
 
     - name: "Build and tag images"
       command: docker build \
-        -t "{{ item.1.name }}:{{ item.0.version }}" \
+        -t "{{ item.1.name }}:{{ item.0.item.version }}" \
         -t "{{ item.1.name }}:latest" \
         -f "{{ item.1.dockerfile }}" .
       args:
         chdir: "{{ item.1.path }}"
+      when: item.0.changed
       with_subelements:
-        - "{{ projects }}"
-        - images
+        - "{{ git_clone.results }}"
+        - item.images
+      tags:
+        # Ignore false ANSIBLE0016 claiming this task should be a handler
+        - skip_ansible_lint
 
     - name: "Publish images"
       command: docker push "{{ item.1.name }}"
+      when: item.0.changed
       with_subelements:
-        - "{{ projects }}"
-        - images
+        - "{{ git_clone.results }}"
+        - item.images
+      tags:
+        # Ignore false ANSIBLE0016 claiming this task should be a handler
+        - skip_ansible_lint

--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -1,8 +1,8 @@
 ---
 
 #
-# Builds core RDSS Archivematica images intended for production deployment and
-# publishes them to the given Docker registry.
+# Builds core RDSSARK images intended for production deployment and publishes
+# them to the given Docker registry.
 #
 # Usage:
 #
@@ -14,57 +14,60 @@
   connection: "local"
 
   vars:
-    repos:
-      - name: "Archivematica repository"
+
+    projects:
+
+      - name: "Archivematica (JiscRDSS fork)"
         repo: "https://github.com/JiscRDSS/archivematica"
         version: "v0.1.0-rc.1"
         dest: "./src/archivematica"
-      - name: "Archivematica Storage Service repository"
+        images:
+          - name: "{{ registry }}archivematica-dashboard"
+            path: "./src/archivematica/src/"
+            dockerfile: "dashboard.Dockerfile"
+          - name: "{{ registry }}archivematica-mcp-server"
+            path: "./src/archivematica/src/"
+            dockerfile: "MCPServer.Dockerfile"
+          - name: "{{ registry }}archivematica-mcp-client"
+            path: "./src/archivematica/src/"
+            dockerfile: "MCPClient.Dockerfile"
+
+      - name: "Archivematica Storage Service (JiscRDSS fork)"
         repo: "https://github.com/JiscRDSS/archivematica-storage-service"
         version: "v0.1.0-rc.1"
         dest: "./src/archivematica-storage-service"
+        images:
+          - name: "{{ registry }}archivematica-storage-service"
+            path: "./src/archivematica-storage-service/"
+            dockerfile: "Dockerfile"
+
       - name: "RDSS Archivematica Automation Tools"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-automation-tools.git"
         version: "v0.1.0-rc.1"
         dest: "./src/rdss-archivematica-automation-tools"
+        images:
+          - name: "{{ registry }}archivematica-automation-tools"
+            path: "./src/rdss-archivematica-automation-tools/"
+            dockerfile: "Dockerfile"
+
       - name: "RDSS Archivematica Channel Adapter"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
         version: "v0.2.6"
         dest: "./src/rdss-archivematica-channel-adapter"
+        images:
+          - name: "{{ registry }}rdss-archivematica-channel-adapter"
+            path: "./src/rdss-archivematica-channel-adapter/"
+            dockerfile: "Dockerfile"
+
       - name: "RDSS Arkivum NextCloud"
         repo: "https://github.com/JiscRDSS/rdss-arkivum-nextcloud"
         version: "v0.1.0-rc.1"
         dest: "./src/rdss-arkivum-nextcloud"
         make_target: "build-files-move-app"
-    images:
-      - name: "{{ registry }}archivematica-automation-tools"
-        dockerfile: "Dockerfile"
-        path: "./src/rdss-archivematica-automation-tools/"
-        tag: "v0.1.0-rc.1"
-      - name: "{{ registry }}archivematica-mcp-server"
-        path: "./src/archivematica/src/"
-        dockerfile: "MCPServer.Dockerfile"
-        tag: "v0.1.0-rc.1"
-      - name: "{{ registry }}archivematica-mcp-client"
-        path: "./src/archivematica/src/"
-        dockerfile: "MCPClient.Dockerfile"
-        tag: "latest"
-      - name: "{{ registry }}archivematica-dashboard"
-        path: "./src/archivematica/src/"
-        dockerfile: "dashboard.Dockerfile"
-        tag: "v0.1.0-rc.1"
-      - name: "{{ registry }}archivematica-storage-service"
-        path: "./src/archivematica-storage-service/"
-        dockerfile: "Dockerfile"
-        tag: "v0.1.0-rc.1"
-      - name: "{{ registry }}rdss-archivematica-channel-adapter"
-        dockerfile: "Dockerfile"
-        path: "./src/rdss-archivematica-channel-adapter/"
-        tag: "v0.2.6"
-      - name: "{{ registry }}nextcloud"
-        dockerfile: "Dockerfile"
-        path: "./src/rdss-arkivum-nextcloud/"
-        tag: "v0.1.0-rc.1"
+        images:
+          - name: "{{ registry }}nextcloud"
+            path: "./src/rdss-arkivum-nextcloud/"
+            dockerfile: "Dockerfile"
 
   tasks:
 
@@ -87,24 +90,28 @@
         repo: "{{ item.repo }}"
         dest: "{{ item.dest }}"
         version: "{{ item.version }}"
-      with_items: "{{ repos }}"
+      with_items: "{{ projects }}"
 
     - name: "Prepare source"
       make:
         chdir: "{{ item.dest }}"
         target: "{{ item.make_target}}"
       when: "item.make_target is defined"
-      with_items: "{{ repos }}"
+      with_items: "{{ projects }}"
 
     - name: "Build and tag images"
       command: docker build \
-        -t "{{ item.name }}:{{ item.tag }}" \
-        -t "{{ item.name }}:latest" \
-        -f "{{ item.dockerfile }}" .
+        -t "{{ item.1.name }}:{{ item.0.version }}" \
+        -t "{{ item.1.name }}:latest" \
+        -f "{{ item.1.dockerfile }}" .
       args:
-        chdir: "{{ item.path }}"
-      with_items: "{{ images }}"
+        chdir: "{{ item.1.path }}"
+      with_subelements:
+        - "{{ projects }}"
+        - images
 
     - name: "Publish images"
-      command: docker push "{{ item.name }}"
-      with_items: "{{ images }}"
+      command: docker push "{{ item.1.name }}"
+      with_subelements:
+        - "{{ projects }}"
+        - images

--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -104,10 +104,10 @@
         - skip_ansible_lint
 
     - name: "Build and tag images"
-      command: docker build \
-        -t "{{ item.1.name }}:{{ item.0.item.version }}" \
-        -t "{{ item.1.name }}:latest" \
-        -f "{{ item.1.dockerfile }}" .
+      command: "docker build
+        -t {{ item.1.name }}:{{ item.0.item.version }}
+        -t {{ item.1.name }}:latest
+        -f {{ item.1.dockerfile }} ."
       args:
         chdir: "{{ item.1.path }}"
       when: item.0.changed

--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -40,11 +40,11 @@
       - name: "{{ registry }}archivematica-automation-tools"
         dockerfile: "Dockerfile"
         path: "./src/rdss-archivematica-automation-tools/"
-        tag: "latest"
+        tag: "v0.1.0-rc.1"
       - name: "{{ registry }}archivematica-mcp-server"
         path: "./src/archivematica/src/"
         dockerfile: "MCPServer.Dockerfile"
-        tag: "latest"
+        tag: "v0.1.0-rc.1"
       - name: "{{ registry }}archivematica-mcp-client"
         path: "./src/archivematica/src/"
         dockerfile: "MCPClient.Dockerfile"
@@ -52,19 +52,19 @@
       - name: "{{ registry }}archivematica-dashboard"
         path: "./src/archivematica/src/"
         dockerfile: "dashboard.Dockerfile"
-        tag: "latest"
+        tag: "v0.1.0-rc.1"
       - name: "{{ registry }}archivematica-storage-service"
         path: "./src/archivematica-storage-service/"
         dockerfile: "Dockerfile"
-        tag: "latest"
+        tag: "v0.1.0-rc.1"
       - name: "{{ registry }}rdss-archivematica-channel-adapter"
         dockerfile: "Dockerfile"
         path: "./src/rdss-archivematica-channel-adapter/"
-        tag: "latest"
+        tag: "v0.2.6"
       - name: "{{ registry }}nextcloud"
         dockerfile: "Dockerfile"
         path: "./src/rdss-arkivum-nextcloud/"
-        tag: "latest"
+        tag: "v0.1.0-rc.1"
 
   tasks:
 
@@ -79,7 +79,7 @@
         extra_args: "--user"
       with_items:
         - "setuptools"
-        - "docker-py"
+        - "docker"
 
     - name: "Clone repositories"
       git:
@@ -96,13 +96,15 @@
       when: "item.make_target is defined"
       with_items: "{{ repos }}"
 
-    - name: "Build and publish images"
-      docker_image:
-        name: "{{ item.name }}"
-        tag: "{{ item.tag }}"
-        path: "{{ item.path }}"
-        dockerfile: "{{ item.dockerfile }}"
-        push: "yes"
-        state: "present"
-        force: "yes"
+    - name: "Build and tag images"
+      command: docker build \
+        -t "{{ item.name }}:{{ item.tag }}" \
+        -t "{{ item.name }}:latest" \
+        -f "{{ item.dockerfile }}" .
+      args:
+        chdir: "{{ item.path }}"
+      with_items: "{{ images }}"
+
+    - name: "Publish images"
+      command: docker push "{{ item.name }}"
       with_items: "{{ images }}"

--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -59,21 +59,30 @@
         repo: "{{ item.repo }}"
         dest: "{{ item.dest }}"
         version: "{{ item.version }}"
+      register: "git_clone"
       with_items: "{{ projects }}"
 
     - name: "Build and tag images"
       command: docker build \
-        -t "{{ item.1.name }}:{{ item.0.version }}" \
+        -t "{{ item.1.name }}:{{ item.0.item.version }}" \
         -t "{{ item.1.name }}:latest" \
         -f "{{ item.1.dockerfile }}" .
       args:
         chdir: "{{ item.1.path }}"
+      when: item.0.changed
       with_subelements:
-        - "{{ projects }}"
-        - images
+        - "{{ git_clone.results }}"
+        - item.images
+      tags:
+        # Ignore false ANSIBLE0016 claiming this task should be a handler
+        - skip_ansible_lint
 
     - name: "Publish images"
       command: docker push "{{ item.1.name }}"
+      when: item.0.changed
       with_subelements:
-        - "{{ projects }}"
-        - images
+        - "{{ git_clone.results }}"
+        - item.images
+      tags:
+        # Ignore false ANSIBLE0016 claiming this task should be a handler
+        - skip_ansible_lint

--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -1,8 +1,8 @@
 ---
 
 #
-# Builds supporting RDSS Archivematica images used for QA and publishes them to
-# the given Docker registry.
+# Builds supporting RDSSARK images used for QA and publishes them to the given
+# Docker registry.
 #
 # Usage:
 #
@@ -14,29 +14,29 @@
   connection: "local"
 
   vars:
-    repos:
+
+    projects:
+
       - name: "RDSS Archivematica Channel Adapter"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
         version: "v0.2.6"
         dest: "./src/rdss-archivematica-channel-adapter"
+        images:
+          - name: "{{ registry }}dynalite"
+            path: "./src/rdss-archivematica-channel-adapter/hack/minikine"
+            dockerfile: "dynalite.Dockerfile"
+          - name: "{{ registry }}minikine"
+            path: "./src/rdss-archivematica-channel-adapter/hack/minikine"
+            dockerfile: "minikine.Dockerfile"
+
       - name: "RDSS Archivematica MsgCreator"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-msgcreator"
         version: "v0.1.0-rc.1"
         dest: "./src/rdss-archivematica-msgcreator"
-    images:
-      - name: "{{ registry }}rdss-archivematica-msgcreator"
-        dockerfile: "Dockerfile"
-        path: "./src/rdss-archivematica-msgcreator/"
-        tag: "v0.1.0-rc.1"
-      - name: "{{ registry }}dynalite"
-        path: "./src/rdss-archivematica-channel-adapter/hack/minikine"
-        dockerfile: "dynalite.Dockerfile"
-        tag: "v0.2.6"
-      - name: "{{ registry }}minikine"
-        path: "./src/rdss-archivematica-channel-adapter/hack/minikine"
-        dockerfile: "minikine.Dockerfile"
-        tag: "v0.2.6"
-
+        images:
+          - name: "{{ registry }}rdss-archivematica-msgcreator"
+            dockerfile: "Dockerfile"
+            path: "./src/rdss-archivematica-msgcreator/"
 
   tasks:
 
@@ -59,17 +59,21 @@
         repo: "{{ item.repo }}"
         dest: "{{ item.dest }}"
         version: "{{ item.version }}"
-      with_items: "{{ repos }}"
+      with_items: "{{ projects }}"
 
     - name: "Build and tag images"
       command: docker build \
-        -t "{{ item.name }}:{{ item.tag }}" \
-        -t "{{ item.name }}:latest" \
-        -f "{{ item.dockerfile }}" .
+        -t "{{ item.1.name }}:{{ item.0.version }}" \
+        -t "{{ item.1.name }}:latest" \
+        -f "{{ item.1.dockerfile }}" .
       args:
-        chdir: "{{ item.path }}"
-      with_items: "{{ images }}"
+        chdir: "{{ item.1.path }}"
+      with_subelements:
+        - "{{ projects }}"
+        - images
 
     - name: "Publish images"
-      command: docker push "{{ item.name }}"
-      with_items: "{{ images }}"
+      command: docker push "{{ item.1.name }}"
+      with_subelements:
+        - "{{ projects }}"
+        - images

--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -63,10 +63,10 @@
       with_items: "{{ projects }}"
 
     - name: "Build and tag images"
-      command: docker build \
-        -t "{{ item.1.name }}:{{ item.0.item.version }}" \
-        -t "{{ item.1.name }}:latest" \
-        -f "{{ item.1.dockerfile }}" .
+      command: "docker build
+        -t {{ item.1.name }}:{{ item.0.item.version }}
+        -t {{ item.1.name }}:latest
+        -f {{ item.1.dockerfile }} ."
       args:
         chdir: "{{ item.1.path }}"
       when: item.0.changed

--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -27,15 +27,15 @@
       - name: "{{ registry }}rdss-archivematica-msgcreator"
         dockerfile: "Dockerfile"
         path: "./src/rdss-archivematica-msgcreator/"
-        tag: "latest"
+        tag: "v0.1.0-rc.1"
       - name: "{{ registry }}dynalite"
         path: "./src/rdss-archivematica-channel-adapter/hack/minikine"
         dockerfile: "dynalite.Dockerfile"
-        tag: "latest"
+        tag: "v0.2.6"
       - name: "{{ registry }}minikine"
         path: "./src/rdss-archivematica-channel-adapter/hack/minikine"
         dockerfile: "minikine.Dockerfile"
-        tag: "latest"
+        tag: "v0.2.6"
 
 
   tasks:
@@ -51,7 +51,7 @@
         extra_args: "--user"
       with_items:
         - "setuptools"
-        - "docker-py"
+        - "docker"
 
     - name: "Clone repositories"
       git:
@@ -61,13 +61,15 @@
         version: "{{ item.version }}"
       with_items: "{{ repos }}"
 
-    - name: "Build and publish images"
-      docker_image:
-        name: "{{ item.name }}"
-        tag: "{{ item.tag }}"
-        path: "{{ item.path }}"
-        dockerfile: "{{ item.dockerfile }}"
-        push: "yes"
-        state: "present"
-        force: "yes"
+    - name: "Build and tag images"
+      command: docker build \
+        -t "{{ item.name }}:{{ item.tag }}" \
+        -t "{{ item.name }}:latest" \
+        -f "{{ item.dockerfile }}" .
+      args:
+        chdir: "{{ item.path }}"
+      with_items: "{{ images }}"
+
+    - name: "Publish images"
+      command: docker push "{{ item.name }}"
       with_items: "{{ images }}"


### PR DESCRIPTION
This pull request addresses issue #107. It changes the Ansible playbooks to tag the built docker images with the specific version number of the project the image is for, as well as the "latest" tag that is used currently.

Applying multiple tags to an image doesn't seem to be possible using the `docker_image` module in Ansible. Instead, I've changed the playbook to use the `command` module, which executes a `docker build -t name:vX.Y.Z -t name:latest .` command for each image.

Adding the version tag, and moving to using semver, has highlighted that we are repeating the version number across the `repos` and `images` collection variables in the playbooks. This is prone to introducing error - if one of the version strings is not updated correctly then it will introduce inconsistencies. It's also implicit which image is built from which repo. With this in mind, my second commit in this pull request replaces the `repos` and `images` variables with a single `projects` variable, in which each project has its repo information but also a list of images as a nested structure. This requires changing the task definitions to use the `with_subelements` construct instead of `with_items`.

This latter change is probably somewhat contraversial, however I beleive it is necessary to make the playbooks easier to understand and maintain going forward. @sevein I would appreciate your views on this.