### PR TITLE
Update images for 0.2.0 release

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -19,7 +19,7 @@
 
       - name: "Archivematica (JiscRDSS fork)"
         repo: "https://github.com/JiscRDSS/archivematica"
-        version: "v0.1.0-rc.1"
+        version: "v0.1.1"
         dest: "./src/archivematica"
         images:
           - name: "{{ registry }}archivematica-dashboard"
@@ -34,7 +34,7 @@
 
       - name: "Archivematica Storage Service (JiscRDSS fork)"
         repo: "https://github.com/JiscRDSS/archivematica-storage-service"
-        version: "v0.1.0-rc.1"
+        version: "v0.2.0"
         dest: "./src/archivematica-storage-service"
         images:
           - name: "{{ registry }}archivematica-storage-service"
@@ -43,7 +43,7 @@
 
       - name: "RDSS Archivematica Automation Tools"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-automation-tools.git"
-        version: "v0.1.0-rc.1"
+        version: "v0.1.1"
         dest: "./src/rdss-archivematica-automation-tools"
         images:
           - name: "{{ registry }}archivematica-automation-tools"
@@ -61,7 +61,7 @@
 
       - name: "RDSS Arkivum NextCloud"
         repo: "https://github.com/JiscRDSS/rdss-arkivum-nextcloud"
-        version: "v0.1.0-rc.1"
+        version: "v0.1.0"
         dest: "./src/rdss-arkivum-nextcloud"
         make_target: "build-files-move-app"
         images:


### PR DESCRIPTION
Updating the ansible script for deploying images to use the most recent archivematica, storage service and automation tools repos.
Updatin nextcloud to use a non-rc tag.

fixes #105