### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,55 +1,35 @@
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-AM_BRANCH := "qa/jisc"
-SS_BRANCH := "qa/jisc"
-AD_BRANCH := "master"
+
+ANSIBLE_PLAYBOOK := $(shell command -v ansible-playbook 2> /dev/null)
+
+check-ansible-playbook:
+ifndef ANSIBLE_PLAYBOOK
+	$(error "ansible-playbook is not available, please install Ansible.")
+endif
 
 build: build-images
 
-build-images: build-image-dashboard build-image-mcpserver build-image-mcpclient build-image-storage-service build-image-automation-tools build-image-nextcloud
+clone: check-ansible-playbook  ## Clone source code repositories.
+	ansible-playbook \
+		--extra-vars="registry=$(REGISTRY)" \
+		--tags=clone \
+			$(ROOT_DIR)/publish-images-playbook.yml \
+			$(ROOT_DIR)/publish-qa-images-playbook.yml
 
-build-image-automation-tools:
-	docker build --rm --pull \
-		--tag rdss-archivematica-automation-tools:latest \
-		-f $(ROOT_DIR)/src/archivematica-automation-tools/Dockerfile \
-			$(ROOT_DIR)/src/archivematica-automation-tools/
+build-images: check-ansible-playbook  ## Build Docker images.
+	ansible-playbook \
+		--extra-vars="registry=$(REGISTRY)" \
+		--tags=clone,build \
+			$(ROOT_DIR)/publish-images-playbook.yml \
+			$(ROOT_DIR)/publish-qa-images-playbook.yml
 
-build-image-dashboard:
-	docker build --rm --pull \
-		--tag rdss-archivematica-dashboard:latest \
-		-f $(ROOT_DIR)/src/archivematica/src/dashboard.Dockerfile \
-			$(ROOT_DIR)/src/archivematica/src/
+publish: check-ansible-playbook  ## Publish Docker images to a registry.
+	ansible-playbook \
+		--extra-vars="registry=$(REGISTRY)" \
+			$(ROOT_DIR)/publish-images-playbook.yml \
+			$(ROOT_DIR)/publish-qa-images-playbook.yml
 
-build-image-mcpserver:
-	docker build --rm --pull \
-		--tag rdss-archivematica-mcpserver:latest \
-		-f $(ROOT_DIR)/src/archivematica/src/MCPServer.Dockerfile \
-			$(ROOT_DIR)/src/archivematica/src/
+help:  ## Print this help message.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build-image-mcpclient:
-	docker build --rm --pull \
-		--tag rdss-archivematica-mcpclient:latest \
-		-f $(ROOT_DIR)/src/archivematica/src/MCPClient.Dockerfile \
-			$(ROOT_DIR)/src/archivematica/src/
-
-build-image-nextcloud:
-	@cd $(ROOT_DIR)/src/rdss-arkivum-nextcloud/ && make build-files-move-app \
-		&& cd .. && \
-		docker build --rm --pull \
-			--tag rdss-arkivum-nextcloud:latest \
-			-f $(ROOT_DIR)/src/rdss-arkivum-nextcloud/Dockerfile \
-				$(ROOT_DIR)/src/rdss-arkivum-nextcloud/
-
-build-image-storage-service:
-	docker build --rm --pull \
-		--tag rdss-archivematica-storage-service:latest \
-		-f $(ROOT_DIR)/src/archivematica-storage-service/Dockerfile \
-			$(ROOT_DIR)/src/archivematica-storage-service/
-
-clone:
-	-git clone --branch $(AM_BRANCH) git@github.com:JiscRDSS/archivematica.git $(ROOT_DIR)/src/archivematica
-	-git clone --branch $(SS_BRANCH) git@github.com:JiscRDSS/archivematica-storage-service.git $(ROOT_DIR)/src/archivematica-storage-service
-	-git clone --branch $(AD_BRANCH) git@github.com:JiscRDSS/rdss-archivematica-channel-adapter.git $(ROOT_DIR)/src/rdss-archivematica-channel-adapter
-	-git clone git@github.com:JiscRDSS/rdss-archivematica-msgcreator.git $(ROOT_DIR)/src/rdss-archivematica-msgcreator
-	-git clone --depth 1 --recursive --branch master https://github.com/artefactual/archivematica-sampledata.git $(ROOT_DIR)/src/archivematica-sampledata
-	-git clone git@github.com:JiscRDSS/rdss-arkivum-nextcloud.git $(ROOT_DIR)/src/rdss-arkivum-nextcloud
-	-git clone --recursive git@github.com:JiscRDSS/rdss-archivematica-automation-tools.git $(ROOT_DIR)/src/rdss-archivematica-automation-tools
+.DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -2,21 +2,22 @@
 
 Integration repo for the RDSS fork of Archivematica.
 
-## Source management
+## Usage
 
-Currently, it is expected that the user clones the corresponding git
-repositories manually. They're expected to be located under the `src/`
-directory. You can use `make clone` to clone these.
+This project uses a Makefile to drive the build. Run `make help` to see a list
+of targets with descriptions, e.g.:
 
-URL | Branch | Components
---- | ------ | ----------
-https://github.com/JiscRDSS/archivematica | qa/jisc | MCPServer, MCPClient, Dashboard
-https://github.com/JiscRDSS/archivematica-storage-service | qa/jisc | Storage Service
-https://github.com/JiscRDSS/rdss-archivematica-automation-tools | master | Automation Tools
-https://github.com/JiscRDSS/rdss-archivematica-channel-adapter | master | Channel Adapter
-https://github.com/JiscRDSS/rdss-archivematica-msgcreator | master | Msgcreator
-https://github.com/JiscRDSS/rdss-arkivum-nextcloud | master | NextCloud
-https://github.com/artefactual/archivematica-sampledata | master | Sample data
+```
+$ make help
+build-images                   Build Docker images.
+clone                          Clone source code repositories.
+help                           Print this help message.
+publish                        Publish Docker images to a registry.
+```
+
+`publish` expects a `REGISTRY` variable to be defined, e.g.:
+
+    $ make publish REGISTRY=aws_account_id.dkr.ecr.region.amazonaws.com/
 
 ## Development environment
 

--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -73,8 +73,8 @@
 
     - name: "Ensure that the variable registry is defined"
       fail:
-        msg: "Variable registry is undefined"
-      when: "registry is not defined"
+        msg: "Variable registry is undefined or empty"
+      when: "(registry is not defined) or (registry | trim == '')"
 
     - name: "Install playbook dependencies"
       pip:
@@ -92,6 +92,8 @@
         version: "{{ item.version }}"
       register: "git_clone"
       with_items: "{{ projects }}"
+      tags:
+        - "clone"
 
     - name: "Prepare source"
       make:
@@ -100,6 +102,7 @@
       when: item.changed and item.item.make_target is defined
       with_items: "{{ git_clone.results }}"
       tags:
+        - "build"
         # Ignore false ANSIBLE0016 claiming this task should be a handler
         - skip_ansible_lint
 
@@ -115,6 +118,7 @@
         - "{{ git_clone.results }}"
         - item.images
       tags:
+        - "build"
         # Ignore false ANSIBLE0016 claiming this task should be a handler
         - skip_ansible_lint
 
@@ -125,5 +129,6 @@
         - "{{ git_clone.results }}"
         - item.images
       tags:
+        - "publish"
         # Ignore false ANSIBLE0016 claiming this task should be a handler
         - skip_ansible_lint

--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -42,8 +42,8 @@
 
     - name: "Ensure that the variable registry is defined"
       fail:
-        msg: "Variable registry is undefined"
-      when: "registry is not defined"
+        msg: "Variable registry is undefined or empty"
+      when: "(registry is not defined) or (registry | trim == '')"
 
     - name: "Install playbook dependencies"
       pip:
@@ -61,6 +61,8 @@
         version: "{{ item.version }}"
       register: "git_clone"
       with_items: "{{ projects }}"
+      tags:
+        - "clone"
 
     - name: "Build and tag images"
       command: "docker build
@@ -74,6 +76,7 @@
         - "{{ git_clone.results }}"
         - item.images
       tags:
+        - "build"
         # Ignore false ANSIBLE0016 claiming this task should be a handler
         - skip_ansible_lint
 
@@ -84,5 +87,6 @@
         - "{{ git_clone.results }}"
         - item.images
       tags:
+        - "publish"
         # Ignore false ANSIBLE0016 claiming this task should be a handler
         - skip_ansible_lint


### PR DESCRIPTION
This pull request brings the existing Make targets in sync to what we're doing
directly via our playbooks (targets `clone` and `build` or `build-images`). It
adds two new targets `publish` and `help`. It uses Ansible tags to run certain
tasks of the playbooks selectively.

See the new bits in the [README.md](https://github.com/JiscRDSS/rdss-archivematica/blob/dev/issue-15-fix-makefile/README.md) file for more details.

This closes #114.