### PR TITLE
deployment: checkout QA copy of channel adapter to different folder

### DIFF
--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -17,26 +17,28 @@
 
     projects:
 
+      # Need to check this out to a separate folder to force images to be built
+      # after main images playbook has been executed
       - name: "RDSS Archivematica Channel Adapter"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
         version: "v0.2.6"
-        dest: "./src/rdss-archivematica-channel-adapter"
+        dest: "./src/qa/rdss-archivematica-channel-adapter"
         images:
           - name: "{{ registry }}dynalite"
-            path: "./src/rdss-archivematica-channel-adapter/hack/minikine"
+            path: "./src/qa/rdss-archivematica-channel-adapter/hack/minikine"
             dockerfile: "dynalite.Dockerfile"
           - name: "{{ registry }}minikine"
-            path: "./src/rdss-archivematica-channel-adapter/hack/minikine"
+            path: "./src/qa/rdss-archivematica-channel-adapter/hack/minikine"
             dockerfile: "minikine.Dockerfile"
 
       - name: "RDSS Archivematica MsgCreator"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-msgcreator"
         version: "v0.1.0-rc.1"
-        dest: "./src/rdss-archivematica-msgcreator"
+        dest: "./src/qa/rdss-archivematica-msgcreator"
         images:
           - name: "{{ registry }}rdss-archivematica-msgcreator"
             dockerfile: "Dockerfile"
-            path: "./src/rdss-archivematica-msgcreator/"
+            path: "./src/qa/rdss-archivematica-msgcreator/"
 
   tasks:
 


### PR DESCRIPTION
This is a minor change to avoid the case where the main images playbook has already been executed and so the Git clone of the `rdss-archivematica-channel-adapter` repo already exists. If this happens, the git-clone task in the QA playbook will detect that nothing has changed, and the docker images for `minikine` and `dynalite` will not be built or published, causing deployment to fail.

Doing a separate checkout for the QA playbook fixes this.

This is necessary for PR #28 to work.