### PR TITLE
compose: fix broken make when using dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,13 +2,7 @@
 *#
 *.swp
 
-/src/archivematica
-/src/archivematica-storage-service
-/src/archivematica-sampledata
-/src/rdss-archivematica-automation-tools
-/src/rdss-archivematica-channel-adapter
-/src/rdss-archivematica-msgcreator
-/src/rdss-arkivum-nextcloud
+/src/*
 
 # Terraform compiled files
 *.tfstate

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -40,8 +40,8 @@ override COMPOSE_FILE ?= $(shell echo \
 	| tr ' ' ':')
 ifeq ("$(ENV)", "dev")
 	# Include qa config because dev overrides/extends this
-	COMPOSE_FILE_2 := "$(COMPOSE_FILE):$(shell realpath ${CURDIR}/docker-compose.qa.yml)"
-	override COMPOSE_FILE="$(COMPOSE_FILE_2)"
+	COMPOSE_FILE_2 := $(COMPOSE_FILE):$(shell realpath ${CURDIR}/docker-compose.qa.yml)
+	override COMPOSE_FILE=$(COMPOSE_FILE_2)
 endif
 export COMPOSE_FILE
 


### PR DESCRIPTION
@sevein has reported a problem whereby the make build for compose doesn't work when using `ENV=dev`:

`docker-compose up -d
ERROR: .IOError: [Errno 2] No such file or directory: u'./""/home/jesus/ram/compose/docker-compose.dev.yml'
make: *** [up] Error 1`

Turns out it's not always a good idea to quote things: make was capturing the quotes as part of the string, which was being passed to docker-compose, rather than just being used to capture the full string.