### PR TITLE
compose: add rdss-siegfried-service

### DIFF
--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -291,6 +291,7 @@ services:
       - "archivematica-dashboard"
       - "minikine"
       - "dynalite"
+      - "rdss-siegfried-service"
     volumes:
       - "${VOL_BASE}/../src/rdss-archivematica-channel-adapter:/go/src/github.com/JiscRDSS/rdss-archivematica-channel-adapter"
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"
@@ -329,3 +330,10 @@ services:
       - "${VOL_BASE}/../src/qa/rdss-archivematica-msgcreator:/go/src/github.com/JiscRDSS/rdss-archivematica-msgcreator"
     expose:
       - "8000"
+
+  rdss-siegfried-service:
+    image: "artefactual/rdss-siegfried-service-amd64:v0.2.3"
+    expose:
+      - "8080"
+    volumes:
+      - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:ro"

--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -52,7 +52,7 @@
 
       - name: "RDSS Archivematica Channel Adapter"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
-        version: "v0.2.6"
+        version: "dev/rdss-siegfried-service"
         dest: "./src/rdss-archivematica-channel-adapter"
         images:
           - name: "{{ registry }}rdss-archivematica-channel-adapter"


### PR DESCRIPTION
This pull request sets up the environment so it's possible to test the second iteration described in [RDSSARK-315](https://jiscdev.atlassian.net/browse/RDSSARK-315) where the files pointed by a `MetadataCreate` message are identified using a new workflow where the new rdss-siegfried-service is used.

The condition for a `MetadataCreate` message to be processed using the new workflow is to contain the substring `PAR` in the `objectTitle` string. For example, I used the following message for my tests:

```json
{
  "messageHeader": {
    "messageId": "e0eece6f-a9b4-ce8f-192c-253d42523e19",
    "messageType": "MetadataCreate",
    "messageClass": "Command"
  },
  "messageBody": {
    "objectUuid": "4fcf8c41-a7f8-7192-20ca-31a2291c1fcb",
    "objectTitle": "Research about ants (PAR)",
    "objectFile": [
      {
        "fileUuid": "d4e09020-e9da-fdda-6aa2-b489a37124b7",
        "fileStorageLocation": "s3://rdss-prod-figshare-0132/foobar.txt",
        "fileStorageType": 1,
        "fileName": "foobar.txt"
      },
      {
        "fileUuid": "55de6626-052d-57ae-6caa-7e8b5fd42a52",
        "fileStorageLocation": "s3://rdss-prod-figshare-0132/giphy.gif",
        "fileStorageType": 1,
        "fileName": "giphy.gif"
      }
    ]
  }
}
```

A new branch of the channel adapter ([dev/rdss-siegfried-service](https://github.com/JiscRDSS/rdss-archivematica-channel-adapter/tree/dev/rdss-siegfried-service)) must be used. It includes two changes: (1) the logic to route messages as described above and, 2) a client of rdss-siegfried-service.

[rdss-siegfried-service](https://github.com/JiscRDSS/rdss-siegfried-service) is deployed using Compose as usually. The application lives in its own repository, it's an application written in Go with a simple HTTP API that takes the path of the file that the user wants to identify. It runs the siegfried identification tool as a subprocess and communicates with it via a UNIX socket.

The channel adapter reports the results as log events, for example:

```
time="2017-11-16T22:56:52Z" level=info msg="Hello!" cmd=consumer version=UNKNOWN
time="2017-11-16T22:56:52Z" level=info msg="Creating new stream processor" cmd=consumer z-backend=kinesis
time="2017-11-16T22:56:52Z" level=info msg="Message received" cmd=consumer count=1 type=MetadataCreate version=UNKNOWN
time="2017-11-16T22:56:52Z" level=info msg="Downloading file s3://rdss-prod-figshare-0132/foobar.txt" cmd=consumer version=UNKNOWN
time="2017-11-16T22:56:52Z" level=debug msg="Saving s3://rdss-prod-figshare-0132/foobar.txt into /var/archivematica/sharedDirectory/tmp/431552861" cmd=consumer version=UNKNOWN
time="2017-11-16T22:56:52Z" level=debug msg="Downloaded s3://rdss-prod-figshare-0132/foobar.txt - 11 bytes written" cmd=consumer version=UNKNOWN
time="2017-11-16T22:56:52Z" level=info msg="File s3://rdss-prod-figshare-0132/foobar.txt was downloaded and identified successfully! PUID x-fmt/111" cmd=consumer version=UNKNOWN
time="2017-11-16T22:56:52Z" level=info msg="Downloading file s3://rdss-prod-figshare-0132/giphy.gif" cmd=consumer version=UNKNOWN
time="2017-11-16T22:56:52Z" level=debug msg="Saving s3://rdss-prod-figshare-0132/giphy.gif into /var/archivematica/sharedDirectory/tmp/554571544" cmd=consumer version=UNKNOWN
time="2017-11-16T22:56:52Z" level=debug msg="Downloaded s3://rdss-prod-figshare-0132/giphy.gif - 1165202 bytes written" cmd=consumer version=UNKNOWN
time="2017-11-16T22:56:52Z" level=info msg="File s3://rdss-prod-figshare-0132/giphy.gif was downloaded and identified successfully! PUID fmt/4" cmd=consumer version=UNKNOWN
```

The rdss-siegfried-service also logs the interactions with its API:

```
ts=2017-11-16T22:55:43.777510263Z v=v0.2.3 level=info api=http://:8080
ts=2017-11-16T22:55:43.77785859Z v=v0.2.3 level=info component=siegfried siegfried=/sf home=/siegfried
ts=2017-11-16T22:56:52.613570375Z v=v0.2.3 level=info component=api method=GET path=/L3Zhci9hcmNoaXZlbWF0aWNhL3NoYXJlZERpcmVjdG9yeS90bXAvNDMxNTUyODYx took=6.634231ms
ts=2017-11-16T22:56:52.688392718Z v=v0.2.3 level=info component=api method=GET path=/L3Zhci9hcmNoaXZlbWF0aWNhL3NoYXJlZERpcmVjdG9yeS90bXAvNTU0NTcxNTQ0 took=14.589801ms
```

See [RDSSARK-315](https://jiscdev.atlassian.net/browse/RDSSARK-315) for more details.