### PR TITLE
Use external docker volumes for MySQL data

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -13,6 +13,7 @@ AM_PIPELINE_DATA ?= /tmp/rdss/am-pipeline-data
 ARK_STORAGE_DATA ?= /tmp/rdss/arkivum-storage
 JISC_TEST_DATA ?= /tmp/rdss/jisc-test-data
 MINIO_EXPORT_DATA ?= /tmp/rdss/minio-export-data
+MYSQL_DATA ?= /tmp/rdss/mysql-data
 SS_LOCATION_DATA ?= /tmp/rdss/am-ss-location-data
 SS_STAGING_DATA ?= /tmp/rdss/am-ss-staging-data
 
@@ -84,10 +85,14 @@ create-volumes:
 	@mkdir -p ${JISC_TEST_DATA}
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(JISC_TEST_DATA) rdss_jisc-test-research-data
-	# Create MINIO named volumes
+	# Create MINIO named volume
 	@mkdir -p ${MINIO_EXPORT_DATA}
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(MINIO_EXPORT_DATA) rdss_minio_export_data
+	# Create MySQL named volume
+	@mkdir -p ${MYSQL_DATA}
+	@docker volume create --opt type=none --opt o=bind \
+		--opt device=$(MYSQL_DATA) rdss_mysql_data
 
 list:
 	docker-compose ps

--- a/compose/docker-compose.nextcloud.yml
+++ b/compose/docker-compose.nextcloud.yml
@@ -1,8 +1,6 @@
 version: '2'
 
 volumes:
-  # Named volume for database persistence
-  mysql_data:
 
   # Named volumes for NextCloud persistence
   nextcloud_apps:
@@ -24,13 +22,16 @@ volumes:
   jisc-test-research-data:
     external:
       name: "rdss_jisc-test-research-data"
+  mysql_data:
+    external:
+      name: "rdss_mysql_data"
 
 services:
 
-  # This is a duplicate definition of the `mysql` service from the dev compose
+  # This is a duplicate definition of the `mysql` service from the qa compose
   # config. We could just use that, however that requires us to depend on the
-  # dev config, which isn't right in all circumstances. Therefore we repeat the
-  # definition, and if the dev config is also included then only one instance
+  # qa config, which isn't right in all circumstances. Therefore we repeat the
+  # definition, and if the qa config is also included then only one instance
   # will be created.
   mysql:
     image: "percona:5.6"
@@ -38,6 +39,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: "12345"
     volumes:
+      - "${VOL_BASE}/dev/etc/mysql/my.cnf:/etc/mysql/my.cnf:ro"
       - "mysql_data:/var/lib/mysql"
     expose:
       - "3306"

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -7,7 +7,6 @@ volumes:
   # These are not accessible outside of the docker host and are maintained by
   # Docker.
   elasticsearch_data:
-  mysql_data:
 
   # External Named Volumes
   # These are intended to be accessible beyond the docker host (e.g. via NFS).
@@ -26,6 +25,9 @@ volumes:
   minio_export_data:
     external:
       name: "rdss_minio_export_data"
+  mysql_data:
+    external:
+      name: "rdss_mysql_data"
 
 services:
 

--- a/compose/qa/Makefile
+++ b/compose/qa/Makefile
@@ -16,17 +16,23 @@ build:
 bootstrap: build bootstrap-storage-service bootstrap-dashboard restart-mcp-services
 
 bootstrap-storage-service:
-	# Wait for services to start properly to avoid race/timing problems
-	@sleep 30
+	# Wait for MySQL to be ready
+	@until docker-compose exec mysql mysql -hlocalhost -uroot -p12345 \
+		-e 'SELECT count(1) FROM mysql.user;' >/dev/null 2>&1 ; do \
+			echo "Waiting for mysql to be ready..." ; \
+			sleep 8 ; \
+	done
+	# Create Storage Service database if required and grant default access
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345 -e "\
-		DROP DATABASE IF EXISTS SS; \
-		CREATE DATABASE SS; \
+		CREATE DATABASE IF NOT EXISTS SS; \
 		GRANT ALL ON SS.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
+	# Run Storage Service database migrations
 	docker-compose run \
 		--rm \
 		--entrypoint /src/storage_service/manage.py \
 			archivematica-storage-service \
 				migrate --noinput
+	# Add initial Storage Service user account
 	docker-compose run \
 		--rm \
 		--entrypoint /src/storage_service/manage.py \
@@ -39,17 +45,23 @@ bootstrap-storage-service:
 					--superuser
 
 bootstrap-dashboard:
-	# Wait for services to start properly to avoid race/timing problems
-	@sleep 30
+	# Wait for MySQL to be ready
+	@until docker-compose exec mysql mysql -hlocalhost -uroot -p12345 \
+		-e 'SELECT count(1) FROM mysql.user;' >/dev/null 2>&1 ; do \
+			echo "Waiting for mysql to be ready..." ; \
+			sleep 8 ; \
+	done
+	# Create Dashboard database if required and grant default access
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345 -e "\
-		DROP DATABASE IF EXISTS MCP; \
-		CREATE DATABASE MCP; \
+		CREATE DATABASE IF NOT EXISTS MCP; \
 		GRANT ALL ON MCP.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
+	# Run Dashboard database migrations
 	docker-compose run \
 		--rm \
 		--entrypoint /src/dashboard/src/manage.py \
 			archivematica-dashboard \
 				migrate --noinput
+	# Add initial Dashboard user account
 	docker-compose run \
 		--rm \
 		--entrypoint /src/dashboard/src/manage.py \


### PR DESCRIPTION
In the compose configuration we're currently using a Docker named volume for storing MySQL data, `mysql_data`. However, this is a Docker-managed named volume, so every time the containers are redeployed it gets destroyed and recreated - causing the data in the database to be lost.

This pull request addresses issue #118 by changing `mysql_data` to be an external Docker volume, which means that Docker won't attempt to manage it itself so won't destroy it when the container is torn down.

I've also changed the bootstrap tasks in the Makefile, which were using `DROP IF EXISTS` instead of `CREATE IF NOT EXISTS` when creating the application databases. As part of this I've also replaced the arbitrary `@sleep 30` command with a more correct `until... done` loop, which waits until an actual SQL query can be successfully executed before considering the database service "up", which makes the whole deployment process much more reliable and predictable (no more "cannot connect to server" even though the `mysql` container is "up").

Hopefully there's nothing contraversial or non-obvious about this, but if there is then let's discuss 🙂 