### PR TITLE
compose: fix playbooks to always use valid docker tags

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -108,7 +108,7 @@
 
     - name: "Build and tag images"
       command: "docker build
-        -t {{ item.1.name }}:{{ item.0.item.version }}
+        -t {{ item.1.name }}:{{ item.0.item.version | regex_replace('/', '_')  | truncate(128, True)}}
         -t {{ item.1.name }}:latest
         -f {{ item.1.dockerfile }} ."
       args:

--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -68,7 +68,7 @@
 
     - name: "Build and tag images"
       command: "docker build
-        -t {{ item.1.name }}:{{ item.0.item.version }}
+        -t {{ item.1.name }}:{{ item.0.item.version | regex_replace('/', '_')  | truncate(128, True)}}
         -t {{ item.1.name }}:latest
         -f {{ item.1.dockerfile }} ."
       args:


### PR DESCRIPTION
This addresses issue #125.

When using a non-semver "version" like a branch name (e.g. `qa/jisc`) the string being used to tag built Docker images wasn't valid syntax according to the Docker tag format. This fixes that, replacing invalid characters with `_` (currently only `/`, since this is the most likely to appear within a branch name). We also truncate the name string to 128, to adhere to the limit imposed by Docker.