### PR TITLE
Set archivematica version and agent code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 ANSIBLE_PLAYBOOK := $(shell command -v ansible-playbook 2> /dev/null)
 
+VERSION = $(shell git describe --tags --always --dirty)
+
 check-ansible-playbook:
 ifndef ANSIBLE_PLAYBOOK
 	$(error "ansible-playbook is not available, please install Ansible.")
@@ -11,21 +13,21 @@ build: build-images
 
 clone: check-ansible-playbook  ## Clone source code repositories.
 	ansible-playbook \
-		--extra-vars="registry=$(REGISTRY)" \
+		--extra-vars="registry=$(REGISTRY) rdss_version=$(VERSION)" \
 		--tags=clone \
 			$(ROOT_DIR)/publish-images-playbook.yml \
 			$(ROOT_DIR)/publish-qa-images-playbook.yml
 
 build-images: check-ansible-playbook  ## Build Docker images.
 	ansible-playbook \
-		--extra-vars="registry=$(REGISTRY)" \
+		--extra-vars="registry=$(REGISTRY) rdss_version=$(VERSION)" \
 		--tags=clone,build \
 			$(ROOT_DIR)/publish-images-playbook.yml \
 			$(ROOT_DIR)/publish-qa-images-playbook.yml
 
 publish: check-ansible-playbook  ## Publish Docker images to a registry.
 	ansible-playbook \
-		--extra-vars="registry=$(REGISTRY)" \
+		--extra-vars="registry=$(REGISTRY) rdss_version=$(VERSION)" \
 			$(ROOT_DIR)/publish-images-playbook.yml \
 			$(ROOT_DIR)/publish-qa-images-playbook.yml
 

--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -6,10 +6,17 @@ DEFAULT_COMPOSE_FILE = $(shell realpath ../docker-compose.dev.yml)
 
 COMPOSE_FILE ?= "${DEFAULT_COMPOSE_FILE}"
 
+VERSION = $(shell git describe --tags --always --dirty)
+
 all: destroy bootstrap
 	docker-compose ps
 
-build:
+versionfile:
+	@echo "\
+	version: ${VERSION}\n\
+	agent_code: ${VERSION}" > ../../src/archivematica/src/version.yml
+
+build: versionfile
 	# Specify compose file explicitly, we don't want to build any other container sets
 	COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
 
@@ -50,6 +57,11 @@ bootstrap-dashboard:
 		--entrypoint /src/dashboard/src/manage.py \
 			archivematica-dashboard \
 				migrate --noinput
+	docker-compose run \
+		--rm \
+		--entrypoint /src/dashboard/src/manage.py \
+			archivematica-dashboard \
+				set_agent_code --agent-code=$(VERSION)
 	docker-compose run \
 		--rm \
 		--entrypoint /src/dashboard/src/manage.py \

--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -2,7 +2,7 @@
 
 BASE_DIR ?= ${CURDIR}
 
-DEFAULT_COMPOSE_FILE = $(shell realpath ../docker-compose.dev.yml)
+DEFAULT_COMPOSE_FILE = $(shell realpath ../docker-compose.qa.yml):$(shell realpath ../docker-compose.dev.yml)
 
 COMPOSE_FILE ?= "${DEFAULT_COMPOSE_FILE}"
 
@@ -11,14 +11,8 @@ VERSION = $(shell git describe --tags --always --dirty)
 all: destroy bootstrap
 	docker-compose ps
 
-versionfile:
-	@echo "\
-	version: ${VERSION}\n\
-	agent_code: ${VERSION}" > ../../src/archivematica/src/version.yml
-
-build: versionfile
-	# Specify compose file explicitly, we don't want to build any other container sets
-	COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
+build:
+	VERSION=$(VERSION) COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
 
 bootstrap: build bootstrap-storage-service bootstrap-dashboard bootstrap-dashboard-frontend restart-mcp-services
 

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -219,6 +219,10 @@ services:
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"
     expose:
       - "8000"
+    build:
+      args:
+        ARCHIVEMATICA_VERSION: "${VERSION}"
+        AGENT_CODE: "${VERSION}"
     links:
       # TODO Replace this with reference to AWS RDS hosted MySQL for QA
       - "mysql"

--- a/compose/qa/Makefile
+++ b/compose/qa/Makefile
@@ -6,12 +6,14 @@ DEFAULT_COMPOSE_FILE = $(shell realpath ../docker-compose.qa.yml)
 
 COMPOSE_FILE ?= "${DEFAULT_COMPOSE_FILE}"
 
+VERSION = $(shell git describe --tags --always --dirty)
+
 all: destroy bootstrap
 	docker-compose ps
 
 build:
 	# Specify compose file explicitly, we don't want to build any other container sets
-	COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
+	VERSION=$(VERSION) COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
 
 bootstrap: build bootstrap-storage-service bootstrap-dashboard  bootstrap-dashboard-frontend restart-mcp-services
 

--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -110,6 +110,8 @@
       command: "docker build
         -t {{ item.1.name }}:{{ item.0.item.version | regex_replace('/', '_')  | truncate(128, True)}}
         -t {{ item.1.name }}:latest
+        --build-arg ARCHIVEMATICA_VERSION={{ rdss_version }}
+        --build-arg AGENT_CODE={{ rdss_version }}
         -f {{ item.1.dockerfile }} ."
       args:
         chdir: "{{ item.1.path }}"

--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -70,6 +70,8 @@
       command: "docker build
         -t {{ item.1.name }}:{{ item.0.item.version | regex_replace('/', '_')  | truncate(128, True)}}
         -t {{ item.1.name }}:latest
+        --build-arg ARCHIVEMATICA_VERSION={{ rdss_version }}
+        --build-arg AGENT_CODE={{ rdss_version }}
         -f {{ item.1.dockerfile }} ."
       args:
         chdir: "{{ item.1.path }}"


### PR DESCRIPTION
* Get version from git tags and write to yml file for build
* Run set-agent-code command on dashboard to override migration

I tried to get this working with docker `--build-args` but couldn't get the docker build to dynamically write a file containing the arg values that would actually show up on the image (possibly related to the order in which things are done during build?). So the makefile writes that file at the start of the build, and docker will pick it up and add it in to the image.

Archivematica PR: https://github.com/JiscRDSS/archivematica/pull/48