### PR TITLE
deployment: update playbooks for v0.3.0-rc1

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -19,7 +19,7 @@
 
       - name: "Archivematica (JiscRDSS fork)"
         repo: "https://github.com/JiscRDSS/archivematica"
-        version: "v0.1.1"
+        version: "v0.2.0-rc1"
         dest: "./src/archivematica"
         images:
           - name: "{{ registry }}archivematica-dashboard"
@@ -52,7 +52,7 @@
 
       - name: "RDSS Archivematica Channel Adapter"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
-        version: "v0.2.6"
+        version: "v0.3.0"
         dest: "./src/rdss-archivematica-channel-adapter"
         images:
           - name: "{{ registry }}rdss-archivematica-channel-adapter"

--- a/publish-qa-images-playbook.yml
+++ b/publish-qa-images-playbook.yml
@@ -21,7 +21,7 @@
       # after main images playbook has been executed
       - name: "RDSS Archivematica Channel Adapter"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
-        version: "v0.2.6"
+        version: "v0.3.0"
         dest: "./src/qa/rdss-archivematica-channel-adapter"
         images:
           - name: "{{ registry }}dynalite"
@@ -33,7 +33,7 @@
 
       - name: "RDSS Archivematica MsgCreator"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-msgcreator"
-        version: "v0.1.0-rc.1"
+        version: "v0.1.0"
         dest: "./src/qa/rdss-archivematica-msgcreator"
         images:
           - name: "{{ registry }}rdss-archivematica-msgcreator"


### PR DESCRIPTION
This updates the `JiscRDSS/archivematica` version to `v0.2.0-rc1`and the Channel Adapter to `v0.3.0`. Also updates the MsgCreator to `v0.1.0`.

Once we pass QA for this release the `JiscRDSS/archivematica` version can be set to `v0.2.0` and this repo's version can be tagged as `v0.3.0`. This will be done in another PR.