### PR TITLE
Update playbook for v0.3.0 release

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -19,7 +19,7 @@
 
       - name: "Archivematica (JiscRDSS fork)"
         repo: "https://github.com/JiscRDSS/archivematica"
-        version: "v0.2.0-rc1"
+        version: "v0.2.0"
         dest: "./src/archivematica"
         images:
           - name: "{{ registry }}archivematica-dashboard"


### PR DESCRIPTION
Changed the version of JiscRDSS/archivematica to `v0.2.0`.

**However...**

This pull request depends on [v0.2.0](https://github.com/JiscRDSS/archivematica/releases/tag/untagged-78eb6ec922177cf2a8ee) being out of draft status, otherwise the tag won't exist.

It also needs to be applied **before** 259ceb7bf50d1fb9d772821d143be14c288753f8 because the [change in JiscRDSS/archivematica](https://github.com/JiscRDSS/archivematica/commit/38a28ef8c1612e3869065fee132069a3d418d80e) that it depends on isn't in the `v0.2.0` release. Ideally this commit shouldn't have been merge to `master` yet, but since it has we need to cherry-pick it to a different branch (e.g. `develop`) so that it isn't lost and then revert the change in the `master` branch until this `v0.3.0` release is done.