### PR TITLE
Use elasticsearch data and autotools db as external volumes.

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -9,8 +9,10 @@ COMPOSE_DIRS ?= $(ENV)
 BASE_DIR ?= ${CURDIR}
 
 # Paths for Docker named volumes
+AM_AUTOTOOLS_DATA ?= /tmp/rdss/am-autotools-data
 AM_PIPELINE_DATA ?= /tmp/rdss/am-pipeline-data
 ARK_STORAGE_DATA ?= /tmp/rdss/arkivum-storage
+ELASTICASEARCH_DATA ?= /tmp/rdss/elasticsearch-data
 JISC_TEST_DATA ?= /tmp/rdss/jisc-test-data
 MINIO_EXPORT_DATA ?= /tmp/rdss/minio-export-data
 MYSQL_DATA ?= /tmp/rdss/mysql-data
@@ -68,6 +70,9 @@ config:
 
 create-volumes:
 	# Create Archivematica named volumes
+	@mkdir -p ${AM_AUTOTOOLS_DATA}
+	@docker volume create --opt type=none --opt o=bind \
+                --opt device=$(AM_AUTOTOOLS_DATA) rdss_am-autotools-data
 	@mkdir -p ${AM_PIPELINE_DATA}
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(AM_PIPELINE_DATA) rdss_am-pipeline-data
@@ -84,6 +89,10 @@ create-volumes:
 	@mkdir -p ${ARK_STORAGE_DATA}/aipingest
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(ARK_STORAGE_DATA) rdss_arkivum-storage
+	# Create ElasticSearch named volume
+	@mkdir -p ${ELASTICSEARCH_DATA}
+	@docker volume create --opt type=none --opt o=bind \
+                --opt device=$(ELASTICSEARCH_DATA) rdss_elasticsearch-data
 	# Create Jisc named volumes
 	@mkdir -p ${JISC_TEST_DATA}
 	@docker volume create --opt type=none --opt o=bind \

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -6,13 +6,15 @@ volumes:
   # Internal Named Volumes
   # These are not accessible outside of the docker host and are maintained by
   # Docker.
-  elasticsearch_data:
 
   # External Named Volumes
   # These are intended to be accessible beyond the docker host (e.g. via NFS).
   # They use bind mounts to mount a specific "local" directory on the docker
   # host - the expectation being that these directories are actually mounted
   # filesystems from elsewhere.
+  archivematica_autotools_data:
+    external:
+      name: "rdss_am-autotools-data"
   archivematica_pipeline_data:
     external:
       name: "rdss_am-pipeline-data"
@@ -22,6 +24,9 @@ volumes:
   archivematica_storage_service_staging_data:
     external:
       name: "rdss_am-ss-staging-data"
+  elasticsearch_data:
+    external:
+      name: "rdss_elasticsearch-data"
   minio_export_data:
     external:
       name: "rdss_minio_export_data"
@@ -147,6 +152,7 @@ services:
       AM_TOOLS_TRANSFER_SS_USER: "test"
     volumes:
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory"
+      - "archivematica_autotools_data:/var/archivematica/automation-tools"
     links:
       - "archivematica-dashboard"
       - "archivematica-storage-service"


### PR DESCRIPTION
In the compose configuration we're currently using a Docker named volume for storing elasticsearch data, elasticsearch_data. However, this is a Docker-managed named volume, so every time the containers are redeployed it gets destroyed and recreated - causing the elasticsearch data to be lost.

In the case of the automation-tools database, the transfer.db was also lost when redeploying, although in this case there was no docker-manager named volume for this. 
When this happened, all transfers in the automated transfer directory were reprocessed.

So, two external volumes have been created:

- rdss_elasticsearch_data: Elasticsearch data directory.
- rdss_am-autotools-data: Automationtools directory that contains the transfers.db file.

This PR closes #133.