### PR TITLE
Add bootstrap for SS locations

### DIFF
--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -49,7 +49,7 @@ bootstrap-storage-service:
 		python /rdss/create-storage-locations.py \
 			--base-url http://localhost:8000 \
 			--api-user test \
-			--api-pass test
+			--api-key test
 
 bootstrap-dashboard:
 	# Wait for MySQL to be ready

--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -37,6 +37,9 @@ bootstrap-storage-service:
 					--email="test@test.com" \
 					--api-key="test" \
 					--superuser
+	# Create RDSS storage locations
+	docker-compose exec archivematica-storage-service \
+		python /rdss/create-storage-locations.py
 
 bootstrap-dashboard:
 	# Wait for services to start properly to avoid race/timing problems

--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -46,7 +46,10 @@ bootstrap-storage-service:
 					--superuser
 	# Create RDSS storage locations
 	docker-compose exec archivematica-storage-service \
-		python /rdss/create-storage-locations.py
+		python /rdss/create-storage-locations.py \
+			--base-url http://localhost:8000 \
+			--api-user test \
+			--api-pass test
 
 bootstrap-dashboard:
 	# Wait for MySQL to be ready

--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -16,17 +16,24 @@ build:
 bootstrap: build bootstrap-storage-service bootstrap-dashboard bootstrap-dashboard-frontend restart-mcp-services
 
 bootstrap-storage-service:
-	# Wait for services to start properly to avoid race/timing problems
-	@sleep 30
+	# Wait for MySQL to be ready
+	@until docker-compose exec mysql mysql -hlocalhost -uroot -p12345 \
+		-e 'SELECT count(1) FROM mysql.user;' >/dev/null 2>&1 ; do \
+			echo "Waiting for mysql to be ready..." ; \
+			sleep 8 ; \
+	done
+	# Create Storage Service database (wiping existing) and grant default access
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345 -e "\
 		DROP DATABASE IF EXISTS SS; \
 		CREATE DATABASE SS; \
 		GRANT ALL ON SS.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
+	# Run Storage Service database migrations
 	docker-compose run \
 		--rm \
 		--entrypoint /src/storage_service/manage.py \
 			archivematica-storage-service \
 				migrate --noinput
+	# Add initial Storage Service user account
 	docker-compose run \
 		--rm \
 		--entrypoint /src/storage_service/manage.py \
@@ -42,17 +49,24 @@ bootstrap-storage-service:
 		python /rdss/create-storage-locations.py
 
 bootstrap-dashboard:
-	# Wait for services to start properly to avoid race/timing problems
-	@sleep 30
+	# Wait for MySQL to be ready
+	@until docker-compose exec mysql mysql -hlocalhost -uroot -p12345 \
+		-e 'SELECT count(1) FROM mysql.user;' >/dev/null 2>&1 ; do \
+			echo "Waiting for mysql to be ready..." ; \
+			sleep 8 ; \
+	done
+	# Create Dashboard database (wiping existing) and grant default access
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345 -e "\
 		DROP DATABASE IF EXISTS MCP; \
 		CREATE DATABASE MCP; \
 		GRANT ALL ON MCP.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
+	# Run Dashboard database migrations
 	docker-compose run \
 		--rm \
 		--entrypoint /src/dashboard/src/manage.py \
 			archivematica-dashboard \
 				migrate --noinput
+	# Add initial Dashboard user account
 	docker-compose run \
 		--rm \
 		--entrypoint /src/dashboard/src/manage.py \
@@ -109,4 +123,4 @@ watch-am:
 watch-ss:
 	docker-compose logs -f archivematica-storage-service
 
-.PHONY: default destroy bootstrap build bootstrap-dashboard bootstrap-storage-service config create-secrets list restart-mcp-services
+.PHONY: default destroy bootstrap build bootstrap-dashboard bootstrap-dashboard-frontend bootstrap-storage-service config create-secrets list restart-mcp-services

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -244,6 +244,7 @@ services:
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"
       - "archivematica_storage_service_staging_data:/var/archivematica/storage_service:rw"
       - "archivematica_storage_service_location_data:/home:rw"
+      - "${VOL_BASE}/qa/etc/rdss-create-storage-locations.py:/rdss/create-storage-locations.py:ro"
     expose:
       - "8000"
     links:

--- a/compose/qa/Makefile
+++ b/compose/qa/Makefile
@@ -48,7 +48,7 @@ bootstrap-storage-service:
 		python /rdss/create-storage-locations.py \
 			--base-url http://localhost:8000 \
 			--api-user test \
-			--api-pass test
+			--api-key test
 
 bootstrap-dashboard:
 	# Wait for MySQL to be ready

--- a/compose/qa/Makefile
+++ b/compose/qa/Makefile
@@ -43,6 +43,9 @@ bootstrap-storage-service:
 					--email="test@test.com" \
 					--api-key="test" \
 					--superuser
+	# Create RDSS storage locations
+	docker-compose exec archivematica-storage-service \
+		python /rdss/create-storage-locations.py
 
 bootstrap-dashboard:
 	# Wait for MySQL to be ready

--- a/compose/qa/Makefile
+++ b/compose/qa/Makefile
@@ -45,7 +45,10 @@ bootstrap-storage-service:
 					--superuser
 	# Create RDSS storage locations
 	docker-compose exec archivematica-storage-service \
-		python /rdss/create-storage-locations.py
+		python /rdss/create-storage-locations.py \
+			--base-url http://localhost:8000 \
+			--api-user test \
+			--api-pass test
 
 bootstrap-dashboard:
 	# Wait for MySQL to be ready

--- a/compose/qa/Makefile
+++ b/compose/qa/Makefile
@@ -121,4 +121,4 @@ watch-am:
 watch-ss:
 	docker-compose logs -f archivematica-storage-service
 
-.PHONY: default destroy bootstrap build bootstrap-dashboard bootstrap-storage-service config create-secrets list restart-mcp-services
+.PHONY: default destroy bootstrap build bootstrap-dashboard bootstrap-dashboard-frontend bootstrap-storage-service config create-secrets list restart-mcp-services

--- a/compose/qa/etc/rdss-create-storage-locations.py
+++ b/compose/qa/etc/rdss-create-storage-locations.py
@@ -1,0 +1,101 @@
+#!/bin/env python
+
+"""This script aims to create two Transfer Storage locations in the
+Archivematica storage service if they don't already exist. These relate to the
+"automated workflow" and the "interactive workflow" that are used in the RDSS
+deployment.
+
+It first lists the existing Locations defined in the Storage Service via the
+API. It checks to see if any of them have the same path as the two locations we
+wish to add - `/home/automated` and `/home/interactive`.
+
+If either of the two locations do not exist, it creates them. It first obtains
+the resource URIs for the Pipeline and Space that the new locations will be
+added to using the Storage Service API. It assumes that there will only be one
+Pipeline and Space, since this is what is expected in the RDSS deployment.
+
+Having identified the URIs for the pipeline and space, it then uses the API to
+create the required locations."""
+
+import requests
+
+# Iterate through all the existing locations and determine if the "automated"
+# and "interactive" Transfer Source locations already exist
+
+automated_exists = False
+interactive_exists = False
+
+r = requests.get(
+    'http://localhost:8000/api/v2/location/',
+    headers={'Authorization': 'ApiKey test:test'}
+)
+
+for loc in r.json()['objects']:
+    if loc['path'] == '/home/automated':
+        automated_exists = True
+    if loc['path'] == '/home/interactive':
+        interactive_exists = True
+
+if not automated_exists or not interactive_exists:
+    # Get the URI of the pipeline. In RDSS we only have one.
+    pipeline_uri = requests.get(
+            'http://localhost:8000/api/v2/pipeline/',
+            headers={
+                'Authorization': 'ApiKey test:test',
+                'Content-Type': 'application/json'
+            }
+        ).json()['objects'][0]['resource_uri']
+
+    # Get the URI of the space. In RDSS we only have one.
+    space_uri = requests.get(
+            'http://localhost:8000/api/v2/space/',
+            headers={
+                'Authorization': 'ApiKey test:test',
+                'Content-Type': 'application/json'
+            }
+        ).json()['objects'][0]['resource_uri']
+
+    if not automated_exists:
+        # Location for automated workflow doesn't exist, create it
+        r = requests.post(
+            'http://localhost:8000/api/v2/location/',
+            headers={'Authorization': 'ApiKey test:test'},
+            json={
+                'pipeline': [pipeline_uri],
+                'purpose': 'TS',
+                'relative_path': 'home/automated',
+                'description': 'automated workflow',
+                'space': space_uri
+            }
+        )
+        if r.ok:
+            print "Location for automated workflow created."
+        else:
+            print "%s %s" % (r.status_code, r.reason)
+            print r.text
+    else:
+        print "Location for automated workflow already exists."
+
+    if not interactive_exists:
+        # Location for interactive workflow doesn't exist, create it
+        r = requests.post(
+            'http://localhost:8000/api/v2/location/',
+            headers={'Authorization': 'ApiKey test:test'},
+            json={
+                'pipeline': [pipeline_uri],
+                'purpose': 'TS',
+                'relative_path': 'home/interactive',
+                'description': 'interactive workflow',
+                'space': space_uri
+            }
+        )
+        if r.ok:
+            print "Location for interactive workflow created."
+        else:
+            print "%s %s" % (r.status_code, r.reason)
+            print r.text
+    else:
+        print "Location for interactive workflow already exists."
+
+else:
+    print "Locations for automated and interactive workflows already exist."

--- a/compose/qa/etc/rdss-create-storage-locations.py
+++ b/compose/qa/etc/rdss-create-storage-locations.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 """This script aims to create two Transfer Storage locations in the
 Archivematica storage service if they don't already exist. These relate to the
@@ -15,9 +15,28 @@ added to using the Storage Service API. It assumes that there will only be one
 Pipeline and Space, since this is what is expected in the RDSS deployment.
 
 Having identified the URIs for the pipeline and space, it then uses the API to
-create the required locations."""
+create the required locations.
+
+It requires the non-standard 'requests' module to be installed:
+
+`pip install requests`
+
+"""
+
 
 import argparse
+import sys
+
+# Check we have the required 'requests' module installed
+import pkg_resources
+try:
+    pkg_resources.get_distribution('requests')
+except pkg_resources.DistributionNotFound:
+    print "Required module 'requests' not installed, aborting."
+    sys.exit(1)
+
+# We have the required modules, okay to continue
+
 import requests
 
 # Process arguments
@@ -28,8 +47,8 @@ parser.add_argument('--base-url', required=True,
                     help='Base URL of Storage Service API to use.')
 parser.add_argument('--api-user', required=True,
                     help='Username to use when authenticating with the API.')
-parser.add_argument('--api-pass', required=True,
-                    help='Password to use when authenticating with the API.')
+parser.add_argument('--api-key', required=True,
+                    help='Key to use when authenticating with the API.')
 args = parser.parse_args()
 
 # Strip trailing '/' off base_url, if any
@@ -38,7 +57,7 @@ args.base_url = args.base_url.rstrip('/')
 # Output parameters
 print "Using base URL '%s'" % args.base_url
 print "Using API user '%s'" % args.api_user
-print "Using API pass '%s'" % args.api_pass
+print "Using API key '%s'" % args.api_key
 
 # Iterate through all the existing locations and determine if the "automated"
 # and "interactive" Transfer Source locations already exist
@@ -51,7 +70,7 @@ r = requests.get(
     headers={
         'Authorization': 'ApiKey %s:%s' % (
             args.api_user,
-            args.api_pass)
+            args.api_key)
     }
 )
 
@@ -68,7 +87,7 @@ if not automated_exists or not interactive_exists:
             headers={
                 'Authorization': 'ApiKey %s:%s' % (
                     args.api_user,
-                    args.api_pass),
+                    args.api_key),
                 'Content-Type': 'application/json'
             }
         ).json()['objects'][0]['resource_uri']
@@ -79,7 +98,7 @@ if not automated_exists or not interactive_exists:
             headers={
                 'Authorization': 'ApiKey %s:%s' % (
                     args.api_user,
-                    args.api_pass),
+                    args.api_key),
                 'Content-Type': 'application/json'
             }
         ).json()['objects'][0]['resource_uri']
@@ -91,7 +110,7 @@ if not automated_exists or not interactive_exists:
             headers={
                 'Authorization': 'ApiKey %s:%s' % (
                     args.api_user,
-                    args.api_pass)},
+                    args.api_key)},
             json={
                 'pipeline': [pipeline_uri],
                 'purpose': 'TS',
@@ -115,7 +134,7 @@ if not automated_exists or not interactive_exists:
             headers={
                 'Authorization': 'ApiKey %s:%s' % (
                     args.api_user,
-                    args.api_pass)},
+                    args.api_key)},
             json={
                 'pipeline': [pipeline_uri],
                 'purpose': 'TS',

--- a/compose/qa/etc/rdss-create-storage-locations.py
+++ b/compose/qa/etc/rdss-create-storage-locations.py
@@ -17,7 +17,28 @@ Pipeline and Space, since this is what is expected in the RDSS deployment.
 Having identified the URIs for the pipeline and space, it then uses the API to
 create the required locations."""
 
+import argparse
 import requests
+
+# Process arguments
+
+parser = argparse.ArgumentParser(
+                    description='Creates required Storage Service locations.')
+parser.add_argument('--base-url', required=True,
+                    help='Base URL of Storage Service API to use.')
+parser.add_argument('--api-user', required=True,
+                    help='Username to use when authenticating with the API.')
+parser.add_argument('--api-pass', required=True,
+                    help='Password to use when authenticating with the API.')
+args = parser.parse_args()
+
+# Strip trailing '/' off base_url, if any
+args.base_url = args.base_url.rstrip('/')
+
+# Output parameters
+print "Using base URL '%s'" % args.base_url
+print "Using API user '%s'" % args.api_user
+print "Using API pass '%s'" % args.api_pass
 
 # Iterate through all the existing locations and determine if the "automated"
 # and "interactive" Transfer Source locations already exist
@@ -26,8 +47,12 @@ automated_exists = False
 interactive_exists = False
 
 r = requests.get(
-    'http://localhost:8000/api/v2/location/',
-    headers={'Authorization': 'ApiKey test:test'}
+    '%s/api/v2/location/' % args.base_url,
+    headers={
+        'Authorization': 'ApiKey %s:%s' % (
+            args.api_user,
+            args.api_pass)
+    }
 )
 
 for loc in r.json()['objects']:
@@ -39,18 +64,22 @@ for loc in r.json()['objects']:
 if not automated_exists or not interactive_exists:
     # Get the URI of the pipeline. In RDSS we only have one.
     pipeline_uri = requests.get(
-            'http://localhost:8000/api/v2/pipeline/',
+            '%s/api/v2/pipeline/' % args.base_url,
             headers={
-                'Authorization': 'ApiKey test:test',
+                'Authorization': 'ApiKey %s:%s' % (
+                    args.api_user,
+                    args.api_pass),
                 'Content-Type': 'application/json'
             }
         ).json()['objects'][0]['resource_uri']
 
     # Get the URI of the space. In RDSS we only have one.
     space_uri = requests.get(
-            'http://localhost:8000/api/v2/space/',
+            '%s/api/v2/space/' % args.base_uri,
             headers={
-                'Authorization': 'ApiKey test:test',
+                'Authorization': 'ApiKey %s:%s' % (
+                    args.api_user,
+                    args.api_pass),
                 'Content-Type': 'application/json'
             }
         ).json()['objects'][0]['resource_uri']
@@ -58,8 +87,11 @@ if not automated_exists or not interactive_exists:
     if not automated_exists:
         # Location for automated workflow doesn't exist, create it
         r = requests.post(
-            'http://localhost:8000/api/v2/location/',
-            headers={'Authorization': 'ApiKey test:test'},
+            '%s/api/v2/location/' % args.base_url,
+            headers={
+                'Authorization': 'ApiKey %s:%s' % (
+                    args.api_user,
+                    args.api_pass)},
             json={
                 'pipeline': [pipeline_uri],
                 'purpose': 'TS',
@@ -79,8 +111,11 @@ if not automated_exists or not interactive_exists:
     if not interactive_exists:
         # Location for interactive workflow doesn't exist, create it
         r = requests.post(
-            'http://localhost:8000/api/v2/location/',
-            headers={'Authorization': 'ApiKey test:test'},
+            '%s/api/v2/location/' % args.base_url,
+            headers={
+                'Authorization': 'ApiKey %s:%s' % (
+                    args.api_user,
+                    args.api_pass)},
             json={
                 'pipeline': [pipeline_uri],
                 'purpose': 'TS',


### PR DESCRIPTION
When we deploy for RDSS we require two storage service locations to exist: `automated` and `interactive`. Currently, these need to be created manually after each (re)deployment.

This pull request addresses this by building on https://github.com/JiscRDSS/archivematica-storage-service/pull/24 by using the new API added in that PR to automate the creation of these storage locations during the bootstrap stage for the Storage Service container.

This is implemented as a simple Python script that uses the `requests` module (already installed in the Storage Service container) to interact with the SS via its API to check if the required locations exist and if not then create them. The Makefile `bootstrap-storage-service` target invokes this script within the `archivematica-storage-service` container using the `docker-compose exec` command.

Initially I tried to use `curl` and capture the responses in bash, as described by @sevein in https://github.com/JiscRDSS/archivematica-storage-service/pull/24, but this quickly became a soup of different syntaxes as python and curl was wrapped in bash which was wrapped in a docker-compose invocation within a Makefile target. Horrible! Hence why I decided to simplify it by doing everything in Python.

The second commit in this PR is a bit of housekeeping; it makes the way we wait for MySQL to be ready consistent with how it's now done in QA, and also adds a few extra comments, also from the QA config.

I've tested this locally and the storage locations are added as expected, and are visable in the Dashboard Transfer UI. I've also ensured this is idempotent - running the script multiple times won't cause the storage locations to be created multiple times.