### PR TITLE
Deployment: Update playbook for v0.4.0-rc1 Release

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -34,7 +34,7 @@
 
       - name: "Archivematica Storage Service (JiscRDSS fork)"
         repo: "https://github.com/JiscRDSS/archivematica-storage-service"
-        version: "v0.2.0"
+        version: "v0.3.0"
         dest: "./src/archivematica-storage-service"
         images:
           - name: "{{ registry }}archivematica-storage-service"


### PR DESCRIPTION
This change updates the playbook to include v0.3.0 of the Storage service.
Draft release notes for v0.4.0 of rdss-archivematica are here: https://jiscdev.atlassian.net/wiki/spaces/RDSSAR/pages/193889646/v0.4.0+Release+Notes+DRAFT