### PR TITLE
Compose fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 ANSIBLE_PLAYBOOK := $(shell command -v ansible-playbook 2> /dev/null)
 
-VERSION = $(shell git describe --tags --always --dirty)
+VERSION ?= $(shell git describe --tags --always --dirty)
 
 check-ansible-playbook:
 ifndef ANSIBLE_PLAYBOOK

--- a/compose/.env
+++ b/compose/.env
@@ -9,6 +9,10 @@ COMPOSE_PROJECT_NAME=rdss
 # all images will be built by docker-compose.
 REGISTRY=
 
+# The version of this repo. This is expected to be overridden using output from Git,
+# i.e. ` git describe --tags --always --dirty`.
+VERSION="v0.0.0-dirty"
+
 # The base dir for the the project. This needs overriding if deploying to a remote
 # DOCKER_HOST.
 VOL_BASE=.

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -12,7 +12,7 @@ BASE_DIR ?= ${CURDIR}
 AM_AUTOTOOLS_DATA ?= /tmp/rdss/am-autotools-data
 AM_PIPELINE_DATA ?= /tmp/rdss/am-pipeline-data
 ARK_STORAGE_DATA ?= /tmp/rdss/arkivum-storage
-ELASTICASEARCH_DATA ?= /tmp/rdss/elasticsearch-data
+ELASTICSEARCH_DATA ?= /tmp/rdss/elasticsearch-data
 JISC_TEST_DATA ?= /tmp/rdss/jisc-test-data
 MINIO_EXPORT_DATA ?= /tmp/rdss/minio-export-data
 MYSQL_DATA ?= /tmp/rdss/mysql-data
@@ -48,6 +48,10 @@ ifeq ("$(ENV)", "dev")
 endif
 export COMPOSE_FILE
 
+# What version are we building?
+VERSION ?= $(shell git describe --tags --always --dirty)
+export VERSION
+
 all: destroy build create-secrets up bootstrap list
 
 bootstrap create-secrets:
@@ -64,45 +68,46 @@ check-vars:
 	@echo "SHIBBOLETH_IDP = '$(SHIBBOLETH_IDP)'"
 	@echo "COMPOSE_DIRS = '$(COMPOSE_DIRS)'"
 	@echo "COMPOSE_FILE = '$(COMPOSE_FILE)'"
+	@echo "VERSION = '$(VERSION)'"
 
 config:
 	docker-compose config
 
 create-volumes:
 	# Create Archivematica named volumes
-	@mkdir -p ${AM_AUTOTOOLS_DATA}
+	@mkdir -p $(AM_AUTOTOOLS_DATA)
 	@docker volume create --opt type=none --opt o=bind \
-                --opt device=$(AM_AUTOTOOLS_DATA) rdss_am-autotools-data
+		--opt device=$(AM_AUTOTOOLS_DATA) rdss_am-autotools-data
 	@mkdir -p ${AM_PIPELINE_DATA}
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(AM_PIPELINE_DATA) rdss_am-pipeline-data
 	@mkdir -p ${SS_LOCATION_DATA}/automated ${SS_LOCATION_DATA}/interactive
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(SS_LOCATION_DATA) rdss_am-ss-location-data
-	@mkdir -p ${SS_STAGING_DATA}
+	@mkdir -p $(SS_STAGING_DATA)
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(SS_STAGING_DATA) rdss_am-ss-staging-data
 	# Ensure Archivematica dirs are owned by archivematica (333)
-	@chown -R 333:333 ${AM_PIPELINE_DATA} ${SS_LOCATION_DATA} ${SS_STAGING_DATA}
-	@chmod -R a=rwX,+t ${SS_LOCATION_DATA}
+	@chown -R 333:333 $(AM_PIPELINE_DATA) $(SS_LOCATION_DATA) $(SS_STAGING_DATA)
+	@chmod -R a=rwX,+t $(SS_LOCATION_DATA)
 	# Create Arkivum named volumes
-	@mkdir -p ${ARK_STORAGE_DATA}/aipingest
+	@mkdir -p $(ARK_STORAGE_DATA)/aipingest
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(ARK_STORAGE_DATA) rdss_arkivum-storage
 	# Create ElasticSearch named volume
-	@mkdir -p ${ELASTICSEARCH_DATA}
+	@mkdir -p $(ELASTICSEARCH_DATA)
 	@docker volume create --opt type=none --opt o=bind \
-                --opt device=$(ELASTICSEARCH_DATA) rdss_elasticsearch-data
+		--opt device=$(ELASTICSEARCH_DATA) rdss_elasticsearch-data
 	# Create Jisc named volumes
-	@mkdir -p ${JISC_TEST_DATA}
+	@mkdir -p $(JISC_TEST_DATA)
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(JISC_TEST_DATA) rdss_jisc-test-research-data
 	# Create MINIO named volume
-	@mkdir -p ${MINIO_EXPORT_DATA}
+	@mkdir -p $(MINIO_EXPORT_DATA)
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(MINIO_EXPORT_DATA) rdss_minio_export_data
 	# Create MySQL named volume
-	@mkdir -p ${MYSQL_DATA}
+	@mkdir -p $(MYSQL_DATA)
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(MYSQL_DATA) rdss_mysql_data
 

--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -6,13 +6,14 @@ DEFAULT_COMPOSE_FILE = $(shell realpath ../docker-compose.qa.yml):$(shell realpa
 
 COMPOSE_FILE ?= "${DEFAULT_COMPOSE_FILE}"
 
-VERSION = $(shell git describe --tags --always --dirty)
+VERSION ?= $(shell git describe --tags --always --dirty)
+export VERSION
 
 all: destroy bootstrap
 	docker-compose ps
 
 build:
-	VERSION=$(VERSION) COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
+	COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
 
 bootstrap: build bootstrap-storage-service bootstrap-dashboard bootstrap-dashboard-frontend restart-mcp-services
 

--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -46,12 +46,6 @@ bootstrap-storage-service:
 					--email="test@test.com" \
 					--api-key="test" \
 					--superuser
-	# Create RDSS storage locations
-	docker-compose exec archivematica-storage-service \
-		python /rdss/create-storage-locations.py \
-			--base-url http://localhost:8000 \
-			--api-user test \
-			--api-key test
 
 bootstrap-dashboard:
 	# Wait for MySQL to be ready
@@ -91,6 +85,12 @@ bootstrap-dashboard:
 					--ss-url="http://archivematica-storage-service:8000" \
 					--ss-user="test" \
 					--ss-api-key="test"
+	# Create RDSS storage locations
+	docker-compose exec archivematica-storage-service \
+		python /rdss/create-storage-locations.py \
+			--base-url http://localhost:8000 \
+			--api-user test \
+			--api-key test
 
 bootstrap-dashboard-frontend:
 	docker-compose run --rm --no-deps \

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -45,6 +45,9 @@ services:
     build:
       context: "../src/archivematica/src"
       dockerfile: "dashboard.Dockerfile"
+      args:
+        ARCHIVEMATICA_VERSION: "${VERSION}"
+        AGENT_CODE: "${VERSION}"
     volumes:
       - "${VOL_BASE}/../src/archivematica/src/archivematicaCommon/:/src/archivematicaCommon/"
       - "${VOL_BASE}/../src/archivematica/src/dashboard/:/src/dashboard/"

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -225,10 +225,6 @@ services:
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"
     expose:
       - "8000"
-    build:
-      args:
-        ARCHIVEMATICA_VERSION: "${VERSION}"
-        AGENT_CODE: "${VERSION}"
     links:
       # TODO Replace this with reference to AWS RDS hosted MySQL for QA
       - "mysql"

--- a/compose/qa/Makefile
+++ b/compose/qa/Makefile
@@ -46,12 +46,6 @@ bootstrap-storage-service:
 					--email="test@test.com" \
 					--api-key="test" \
 					--superuser
-	# Create RDSS storage locations
-	docker-compose exec archivematica-storage-service \
-		python /rdss/create-storage-locations.py \
-			--base-url http://localhost:8000 \
-			--api-user test \
-			--api-key test
 
 bootstrap-dashboard:
 	# Wait for MySQL to be ready
@@ -85,6 +79,12 @@ bootstrap-dashboard:
 					--ss-url="http://archivematica-storage-service:8000" \
 					--ss-user="test" \
 					--ss-api-key="test"
+	# Create RDSS storage locations
+	docker-compose exec archivematica-storage-service \
+		python /rdss/create-storage-locations.py \
+			--base-url http://localhost:8000 \
+			--api-user test \
+			--api-key test
 
 bootstrap-dashboard-frontend:
 	docker-compose run --rm --no-deps \

--- a/compose/qa/Makefile
+++ b/compose/qa/Makefile
@@ -6,14 +6,15 @@ DEFAULT_COMPOSE_FILE = $(shell realpath ../docker-compose.qa.yml)
 
 COMPOSE_FILE ?= "${DEFAULT_COMPOSE_FILE}"
 
-VERSION = $(shell git describe --tags --always --dirty)
+VERSION ?= $(shell git describe --tags --always --dirty)
+export VERSION
 
 all: destroy bootstrap
 	docker-compose ps
 
 build:
 	# Specify compose file explicitly, we don't want to build any other container sets
-	VERSION=$(VERSION) COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
+	COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
 
 bootstrap: build bootstrap-storage-service bootstrap-dashboard  bootstrap-dashboard-frontend restart-mcp-services
 

--- a/compose/qa/etc/rdss-create-storage-locations.py
+++ b/compose/qa/etc/rdss-create-storage-locations.py
@@ -94,7 +94,7 @@ if not automated_exists or not interactive_exists:
 
     # Get the URI of the space. In RDSS we only have one.
     space_uri = requests.get(
-            '%s/api/v2/space/' % args.base_uri,
+            '%s/api/v2/space/' % args.base_url,
             headers={
                 'Authorization': 'ApiKey %s:%s' % (
                     args.api_user,

--- a/compose/shib-local/idp/bootstrap.sh
+++ b/compose/shib-local/idp/bootstrap.sh
@@ -15,3 +15,13 @@ ${JRE_HOME}/bin/keytool -import -noprompt -trustcacerts -alias ${DOMAIN_NAME} \
 	-file /secrets/${DOMAIN_NAME}-ca.crt \
 	-keystore  ${JRE_HOME}/lib/security/cacerts \
 	-storepass changeit
+
+# Wait for all metadata providers to be available
+for m in $(grep metadataURL /opt/shibboleth-idp/conf/metadata-providers.xml | \
+	sed -r 's/.+="([^"]+).*/\1/') ; do
+	until curl -s -k "${m}" >/dev/null ; do
+		echo "Waiting for ${m} to become available..."
+		sleep 8
+	done
+	echo "Metadata available: ${m}"
+done


### PR DESCRIPTION
This pull request addresses a number of different issues I've encountered when working with the current code in the `qa/0.5.0` branch. The changes are separated into different commits, to maintain atomicity.

Here's what's changed:

1. Fix race condition between IdP and SP. Since I removed the `sleep 30` from the bootstrap, it's unmasked a problem whereby there's a race between the IdP and SP, as both want to be able to retrieve the other's metadata XML. The IdP now parses its `metadata-providers.xml` and waits until all `metadataURL` endpoints are available before allowing the IdP web service to start.
1. Fix errors when creating the SS storage locations during bootstrap. When I added this to the bootstrap, I assumed that the correct place to do it was during the SS bootstrap. This was incorrect. The correct place to do it is in the **Dashboard** bootstrap, as we need the pipeline to exist before we can add Transfer Source locations for it.
1. Fix the way version strings are provided. When I tried to run commands like `make list` I found I couldn't, because there was no default `VERSION` value provided, and not all commands in the Makefile specified that value. We now `export VERSION` so that all commands have it in their context, not just `make build`. I've also added a default `VERSION=v0.0.0-dirty` to the `.env` file so that Docker Compose always has a value in case one is ommitted.

@sevein and @mamedin could you please review? Thanks! 😄 