### PR TITLE
Update nextcloud service to match latest image

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -16,6 +16,8 @@ ELASTICSEARCH_DATA ?= /tmp/rdss/elasticsearch-data
 JISC_TEST_DATA ?= /tmp/rdss/jisc-test-data
 MINIO_EXPORT_DATA ?= /tmp/rdss/minio-export-data
 MYSQL_DATA ?= /tmp/rdss/mysql-data
+NEXTCLOUD_DATA ?= /tmp/rdss/nextcloud-data
+NEXTCLOUD_THEMES ?= /tmp/rdss/nextcloud-themes
 SS_LOCATION_DATA ?= /tmp/rdss/am-ss-location-data
 SS_STAGING_DATA ?= /tmp/rdss/am-ss-staging-data
 
@@ -110,6 +112,12 @@ create-volumes:
 	@mkdir -p $(MYSQL_DATA)
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(MYSQL_DATA) rdss_mysql_data
+	# Create NextCloud named volumes
+	@mkdir -p $(NEXTCLOUD_DATA) $(NEXTCLOUD_THEMES)
+	@docker volume create --opt type=none --opt o=bind \
+		--opt device=$(NEXTCLOUD_DATA) rdss_nextcloud-data
+	@docker volume create --opt type=none --opt o=bind \
+		--opt device=$(NEXTCLOUD_THEMES) rdss_nextcloud-themes
 
 list:
 	docker-compose ps

--- a/compose/README.md
+++ b/compose/README.md
@@ -18,34 +18,52 @@ To allow Archivematica and NextCloud to interact and share data with other syste
 
 | Volume | Description |
 |---|---|
+| `rdss_am-autotools_data` | Used to store data and state for the Automation Tools. |
 | `rdss_am-pipeline_data` | Used to store data shared across Archivematica components. Also used by external systems to input data to Archivematica, and to retrieve outputs from Archivematica (`www/AIPsStore` and `www/DIPsStore`). |
 | `rdss_am-ss-location-data` | Used to provide data storage for the Storage Service. Making this external allows other systems to input data into Archivematica. |
+| `rdss_am-ss-staging-data` | Used to provide data storage for the Storage Service. |
 | `rdss_arkivum-storage` | Used to access storage on an Arkivum appliance (if available). |
 | `rdss_jisc-test-research-data` | Used to access the Jisc RDSS S3 bucket for test research data. |
 | `rdss_minio_export_data` | Expose the `/export` folder that Minio uses to store its data |
+| `rdss_nextcloud-data` | Used to store data and state for NextCloud. |
+| `rdss_nextcloud-themes` | Used to store "themes" for NextCloud. |
 
 To create volumes for directories on the local machine use
 
-	make create-volumes
+	sudo make create-volumes
+
+The reason for using `sudo` is because some of the volume directories may need their permissions changed, so that they are owned by the `333` user that Archivematica uses for its data.
 
 The parameters for the volumes created are as follows, and may be overridden via Makefile arguments:
 
 | Parameter | Description | Default |
 |---|---|---|
-| `AM_PIPELINE_DATA` | The path on the docker host to use for Archivematica's `sharedDirectory` pipeline data. | `/tmp/rdss/am-pipeline-data`
-| `ARK_STORAGE_DATA` | The path on the docker host to use for Arkivum appliance storage. | `/tmp/rdss/arkivum-storage` |
-| `JISC_TEST_DATA` | The path on the docker host to use for accessing the Jisc RDSS S3 bucket for test research data. | `/tmp/rdss/jisc-test-data` |
-| `MINIO_EXPORT_DATA` | The path on the docker host to use for Minio's `/export` folder | `/tmp/rdss/minio-export-data` |
-| `SS_LOCATION_DATA` | The path on the docker host to use for Archivematica's default location in the Storage Service. | `/tmp/rdss/am-ss-location-data` |
+| `AM_AUTOTOOLS_DATA` | Path on the docker host to use for Automation Tools data and state. | `/tmp/rdss/am-autotools-data` |
+| `AM_PIPELINE_DATA` | Path on the docker host to use for Archivematica's `sharedDirectory` pipeline data. | `/tmp/rdss/am-pipeline-data` |
+| `ARK_STORAGE_DATA` | Path on the docker host to use for Arkivum appliance storage. | `/tmp/rdss/arkivum-storage` |
+| `ELASTICSEARCH_DATA` | Path on the docker host to use for ElasticSearch data. | `/tmp/rdss/elasticsearch-data` |
+| `JISC_TEST_DATA` | Path on the docker host to use for accessing the Jisc RDSS S3 bucket for test research data. | `/tmp/rdss/jisc-test-data` |
+| `MINIO_EXPORT_DATA` | Path on the docker host to use for Minio's `/export` folder | `/tmp/rdss/minio-export-data` |
+| `MYSQL_DATA` | Path on the docker host to use for MySQL data. | `/tmp/rdss/mysql-data` |
+| `NEXTCLOUD_DATA` | Path on the docker host to use use for NextCloud data and state. | `/tmp/rdss/nextcloud-data` |
+| `NEXTCLOUD_THEMES` | Path on the docker host to use for NextCloud "theme" data. | `/tmp/rdss/nextcloud-themes` |
+| `SS_LOCATION_DATA` | Path on the docker host to use for Archivematica's default location in the Storage Service. | `/tmp/rdss/am-ss-location-data` |
+| `SS_STAGING_DATA` | Path on the docker host to use for Storage Service staging data. | `/tmp/rdss/am-ss-staging-data` |
 
 For example, to use remote mounts instead of the default locations
 
-	make create-volumes \
+	sudo make create-volumes \
+		AM_AUTOTOOLS_DATA=/mnt/nfs/am-autotools-data \
 		AM_PIPELINE_DATA=/mnt/nfs/am-pipeline-data \
 		ARK_STORAGE_DATA=/mnt/astor \
+		ELASTICSEARCH_DATA=/mnt/nfs/elasticsearch-data \
 		JISC_TEST_DATA=/mnt/s3/jisc-rdss-test-research-data \
-    MINIO_EXPORT_DATA=/mnt/nfs/minio-export-data \
-		SS_LOCATION_DATA=/mnt/nfs/am-ss-default-location-data
+		MINIO_EXPORT_DATA=/mnt/nfs/minio-export-data \
+		MYSQL_DATA=/mnt/nfs/mysql-data \
+		NEXTCLOUD_DATA=/mnt/nfs/nextcloud-data \
+		NEXTCLOUD_THEMES=/mnt/nfs/nextcloud-themes \
+		SS_LOCATION_DATA=/mnt/nfs/am-ss-default-location-data \
+		SS_STAGING_DATA=/mnt/nfs/am-ss-staging-data
 
 Service Sets
 -------------

--- a/compose/docker-compose.nextcloud.yml
+++ b/compose/docker-compose.nextcloud.yml
@@ -2,13 +2,6 @@ version: '2'
 
 volumes:
 
-  # Named volumes for NextCloud persistence
-  nextcloud_apps:
-  nextcloud_config:
-  nextcloud_data:
-  nextcloud_sessions:
-  nextcloud_themes:
-
   # Named external volumes for NextCloud external storage locations for RDSS
   archivematica_pipeline_data:
     external:
@@ -25,6 +18,12 @@ volumes:
   mysql_data:
     external:
       name: "rdss_mysql_data"
+  nextcloud_data:
+    external:
+      name: "rdss_nextcloud-data"
+  nextcloud_themes:
+    external:
+      name: "rdss_nextcloud-themes"
 
 services:
 
@@ -43,6 +42,18 @@ services:
       - "mysql_data:/var/lib/mysql"
     expose:
       - "3306"
+
+  # This is a duplicate definition of the `redis` service from the qa compose
+  # config. We could just use that, however that requires us to depend on the
+  # qa config, which isn't right in all circumstances. Therefore we repeat the
+  # definition, and if the qa config is also included then only one instance
+  # will be created.
+  redis:
+      image: "redis:3.2-alpine"
+      command: '--save "" --appendonly no'  # Persistency disabled
+      user: "redis"
+      expose:
+        - "6379"
 
   nextcloud:
     image: "arkivum/rdss-nextcloud"
@@ -69,11 +80,8 @@ services:
         s3-jisc-test-research:/mnt/jisc-test-research-data"
     volumes:
       # Nextcloud app volumes
-      - "nextcloud_apps:/apps2"
-      - "nextcloud_config:/config"
-      - "nextcloud_data:/data"
+      - "nextcloud_data:/var/lib/nextcloud"
       - "nextcloud_themes:/nextcloud/themes"
-      - "nextcloud_sessions:/php/session"
       # External storage locations
       - "archivematica_pipeline_data:/mnt/am-pipeline-data"
       - "archivematica_storage_service_location_data:/mnt/am-ss-default-location-data"
@@ -83,5 +91,7 @@ services:
       - "${NEXTCLOUD_EXTERNAL_IP}:${NEXTCLOUD_EXTERNAL_PORT}:8888"
     depends_on:
       - "mysql"
+      - "redis"
     links:
       - "mysql"
+      - "redis"

--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -61,7 +61,7 @@
 
       - name: "RDSS Arkivum NextCloud"
         repo: "https://github.com/JiscRDSS/rdss-arkivum-nextcloud"
-        version: "v0.1.0"
+        version: "v0.2.0"
         dest: "./src/rdss-arkivum-nextcloud"
         make_target: "build-files-move-app"
         images:


### PR DESCRIPTION
Recent changes in https://github.com/JiscRDSS/rdss-arkivum-nextcloud require we update the `nextcloud` service in our Docker Compose configuration. In particular, we need to:

1. Make all nextcloud volumes external, so that we persist state and app data correctly
1. Consolidate the 5 nextcloud volumes into `nextcloud_data` and `nextcloud_themes`
1. Add a dependency on the `redis` service, which is used for caching by nextcloud

The `nextcloud_data` volume is mounted as `/var/lib/nextcloud`, which is where NextCloud now stores all of its state and internal data files. In case you're wondering why `nextcloud_themes` is required, it's because the base image uses `/nextcloud/themes` as a volume, so it's not possible to change it without rewriting what is in the base image (which may be required at some point but not right now).

Note that these changes aren't compatible with nextcloud https://github.com/JiscRDSS/rdss-arkivum-nextcloud/releases/tag/v0.1.0 so shouldn't be merged until after a new release of the nextcloud image has been made.