### PR TITLE
Add version info to MCPClient build

### DIFF
--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -36,6 +36,9 @@ services:
     build:
       context: "../src/archivematica/src"
       dockerfile: "MCPClient.Dockerfile"
+      args:
+        ARCHIVEMATICA_VERSION: "${VERSION}"
+        AGENT_CODE: "${VERSION}"
     volumes:
       - "${VOL_BASE}/../src/archivematica/src/archivematicaCommon/:/src/archivematicaCommon/"
       - "${VOL_BASE}/../src/archivematica/src/dashboard/:/src/dashboard/"


### PR DESCRIPTION
Since https://github.com/JiscRDSS/archivematica/pull/51/commits/e899d611616b0b2ba9a39d7e87087db45cc7aa4e the MCPClient now requires version information to be provided, so the compose build needs updating to do this.

Note that this change is dependent on an unreleased change on the https://github.com/JiscRDSS/archivematica/tree/qa/jisc branch, so we should wait for that to be released before merging this pull request.