### PR TITLE
Use same bootstrap for dev as for qa

### DIFF
--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -13,6 +13,7 @@ all: destroy bootstrap
 	docker-compose ps
 
 build:
+	# Specify compose file explicitly, we don't want to build any other container sets
 	COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
 
 bootstrap: build bootstrap-storage-service bootstrap-dashboard bootstrap-dashboard-frontend restart-mcp-services
@@ -24,10 +25,9 @@ bootstrap-storage-service:
 			echo "Waiting for mysql to be ready..." ; \
 			sleep 8 ; \
 	done
-	# Create Storage Service database (wiping existing) and grant default access
+	# Create Storage Service database if required and grant default access
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345 -e "\
-		DROP DATABASE IF EXISTS SS; \
-		CREATE DATABASE SS; \
+		CREATE DATABASE IF NOT EXISTS SS; \
 		GRANT ALL ON SS.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
 	# Run Storage Service database migrations
 	docker-compose run \
@@ -54,10 +54,9 @@ bootstrap-dashboard:
 			echo "Waiting for mysql to be ready..." ; \
 			sleep 8 ; \
 	done
-	# Create Dashboard database (wiping existing) and grant default access
+	# Create Dashboard database if required and grant default access
 	docker-compose exec mysql mysql -hlocalhost -uroot -p12345 -e "\
-		DROP DATABASE IF EXISTS MCP; \
-		CREATE DATABASE MCP; \
+		CREATE DATABASE IF NOT EXISTS MCP; \
 		GRANT ALL ON MCP.* TO 'archivematica'@'%' IDENTIFIED BY 'demo';"
 	# Run Dashboard database migrations
 	docker-compose run \
@@ -65,12 +64,13 @@ bootstrap-dashboard:
 		--entrypoint /src/dashboard/src/manage.py \
 			archivematica-dashboard \
 				migrate --noinput
-	# Add initial Dashboard user account
+	# Set agent code in Dashboard
 	docker-compose run \
 		--rm \
 		--entrypoint /src/dashboard/src/manage.py \
 			archivematica-dashboard \
 				set_agent_code --agent-code=$(VERSION)
+	# Add initial Dashboard user account
 	docker-compose run \
 		--rm \
 		--entrypoint /src/dashboard/src/manage.py \

--- a/compose/qa/Makefile
+++ b/compose/qa/Makefile
@@ -16,7 +16,7 @@ build:
 	# Specify compose file explicitly, we don't want to build any other container sets
 	COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
 
-bootstrap: build bootstrap-storage-service bootstrap-dashboard  bootstrap-dashboard-frontend restart-mcp-services
+bootstrap: build bootstrap-storage-service bootstrap-dashboard bootstrap-dashboard-frontend restart-mcp-services
 
 bootstrap-storage-service:
 	# Wait for MySQL to be ready


### PR DESCRIPTION
I've recently been testing the setup and teardown with `make all ENV=dev` and found that, because the bootstrap destroys the database with a `DROP ... CREATE` for both `SS` and `MCP`, the resulting system that comes up on subsequent redeployments is inconsistent. Symptoms I've seen have included the default location in the SS having a blank `staging_path`, and the 5 required default locations that should be created by [this code](https://github.com/artefactual/archivematica-storage-service/blob/stable/0.11.x/storage_service/locations/models/pipeline.py#L125-L141).

The qa build does not exhibit these problems, because there we changed it to use `CREATE IF NOT EXISTS` instead of `DROP ... CREATE`. I'm therefore proposing that we do the same for dev, even if it means we have to clear down the databases manually when that's the behaviour we actually want.

There are now only two difference between the qa and dev builds:

1. The dev build also includes the `docker-compose.dev.yml` config, so we get the `build:` sections
1. The qa build is currently running a command to set the `agent_code` for the dashboard during bootstrap, because we expect this to already be baked into the pre-built image

This, hopefully, will improve the consistency in behaviour between dev and qa builds and reduce the number of ratholes we need to go down to ascertain whether a problem is environmental or a problem in the code.