### PR TITLE
compose: add destroy-volumes target

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -119,6 +119,48 @@ create-volumes:
 	@docker volume create --opt type=none --opt o=bind \
 		--opt device=$(NEXTCLOUD_THEMES) rdss_nextcloud-themes
 
+destroy-volumes:
+	@echo -n "WARNING! About to delete all data on all volumes! Continue? [yes/no]: " ; \
+	read yn ; \
+	case "$${yn}" in \
+		[Yy][Ee][Ss] ) \
+			docker volume rm \
+				rdss_am-autotools-data \
+				rdss_am-pipeline-data \
+				rdss_am-ss-location-data \
+				rdss_am-ss-staging-data \
+				rdss_arkivum-storage \
+				rdss_elasticsearch-data \
+				rdss_jisc-test-research-data \
+				rdss_minio_export_data \
+				rdss_mysql_data \
+				rdss_nextcloud-data \
+				rdss_nextcloud-themes && \
+				echo "Removed all Docker volumes. " ; \
+			if docker volume list | grep rdss_ >/dev/null ; then \
+				echo "Cannot remove files: docker volumes still in use." ; \
+				exit ;\
+			else \
+				rm -vRf \
+					$(AM_AUTOTOOLS_DATA) \
+					$(AM_PIPELINE_DATA) \
+					$(ARK_STORAGE_DATA) \
+					$(ELASTICSEARCH_DATA) \
+					$(MINIO_EXPORT_DATA) \
+					$(MYSQL_DATA) \
+					$(NEXTCLOUD_DATA) \
+					$(NEXTCLOUD_THEMES) \
+					$(SS_LOCATION_DATA) \
+					$(SS_STAGING_DATA) && \
+				echo "Removed all files." ; \
+			fi ; \
+			;; \
+		[Nn][Oo] ) \
+			;; \
+		*) \
+			echo "Invalid answer, must be 'yes' or 'no'." ;; \
+	esac ; \
+
 list:
 	docker-compose ps
 

--- a/compose/README.md
+++ b/compose/README.md
@@ -28,6 +28,8 @@ To allow Archivematica and NextCloud to interact and share data with other syste
 | `rdss_nextcloud-data` | Used to store data and state for NextCloud. |
 | `rdss_nextcloud-themes` | Used to store "themes" for NextCloud. |
 
+### Creating External Volumes
+
 To create volumes for directories on the local machine use
 
 	sudo make create-volumes
@@ -64,6 +66,16 @@ For example, to use remote mounts instead of the default locations
 		NEXTCLOUD_THEMES=/mnt/nfs/nextcloud-themes \
 		SS_LOCATION_DATA=/mnt/nfs/am-ss-default-location-data \
 		SS_STAGING_DATA=/mnt/nfs/am-ss-staging-data
+
+### Destroying External Volumes
+
+After the containers have been torn down using `make destroy`, the external volumes will, by default, remain in place, both as Docker volumes and also in terms of the files remaining intact within the defined locations.
+
+If you wish to destroy the Docker volumes and the data within each of the locations, use the following:
+
+	sudo make destroy-volumes
+
+This must be used with caution, which is why you will be prompted to confirm you really wish to carry out the action. Saying "yes" will remove all traces of your data - so is only suitable for development and test environments or if you **really know what you are doing**!
 
 Service Sets
 -------------


### PR DESCRIPTION
We have the `create-volumes` target but no way to clean them up after destroy. This pull request adds a `destroy-volumes` target fills this gap, removing all of the docker volumes we create and also removing all files from the defined paths. This is obviously dangerous, so we ask the user to confirm their intent before doing anything.

Note that the removal of the files will likely require `sudo` rights, but I haven't put it in the script because I don't want to add a dependency on `sudo` rights actually into the Makefile itself.

This doesn't/shouldn't affect anything production based; it's mostly only of use in a development environment, since that's the only place where the various volume locations aren't going to be remote mounts.