### PR TITLE
Deployment: update deploy.sh for v0.5.0 release

### DIFF
--- a/aws/machine/deploy.sh
+++ b/aws/machine/deploy.sh
@@ -300,7 +300,7 @@ prepare_dockerhost()
             git clone --branch '${RDSSARK_VERSION}' \
                 ${RDSS_ARCHIVEMATICA_REPO} ${clone_dir} && \
             ansible-playbook  \
-                --extra-vars='registry=localhost:5000/' \
+                --extra-vars='registry=localhost:5000/ rdss_version=${RDSSARK_VERSION}' \
                 ${clone_dir}/publish-images-playbook.yml \
                 ${clone_dir}/publish-qa-images-playbook.yml"
 }


### PR DESCRIPTION
The ansible playbooks need the extra-variable rdss_version for v0.5.0 release.

This closes #156 