### PR TITLE
compose: Configure Elasticsearch heap size

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -68,6 +68,13 @@ AM_STORAGE_SERVICE_EXTERNAL_PORT=8443
 # or Dashboard.
 AM_DEFAULT_FROM_EMAIL=noreply@researchdata.alpha.jisc.ac.uk
 
+## Elasticsearch ##############################################################
+
+# HEAP size, ensuring that the min (Xms) and max (Xmx) sizes are the same,
+# preventing the heap from being resized at runtime, a very costly process. The
+# default JVM memory settings (-Xms256m -Xmx1g) is insufficient and costly.
+ES_HEAP_SIZE=1g
+
 ## NextCloud ##################################################################
 
 # The external IP address for the NextCloud service. By default we bind to all

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -67,6 +67,9 @@ services:
   elasticsearch:
     image: "elasticsearch:1.7-alpine"
     command: "elasticsearch -Des.node.name=TestNode -Des.network.host=0.0.0.0"
+    environment:
+      - "ES_MIN_MEM=${ES_HEAP_SIZE}"
+      - "ES_MAX_MEM=${ES_HEAP_SIZE}"
     privileged: yes
     volumes:
       - "elasticsearch_data:/usr/share/elasticsearch/data"


### PR DESCRIPTION
Added the env variable `ES_HEAP_SIZE` for JVM HEAP size, ensuring that the min
(Xms) and max (Xmx) sizes are the same, preventing the heap from being resized
at runtime, a very costly process.

It closes #161