### PR TITLE
revert channel adapter to v0.4.0

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -52,7 +52,7 @@
 
       - name: "RDSS Archivematica Channel Adapter"
         repo: "https://github.com/JiscRDSS/rdss-archivematica-channel-adapter"
-        version: "v0.5.0"
+        version: "v0.4.0"
         dest: "./src/rdss-archivematica-channel-adapter"
         images:
           - name: "{{ registry }}rdss-archivematica-channel-adapter"


### PR DESCRIPTION
I suggest that a new v0.6.0-rc2 tag be made for rdss-archivematica after this PR is approved and merged.

v0.5.0 of the channel adapter will not accept invalid messages
from samvera.  This may break in production at the moment.

v0.4.0 is safe to deploy to production, and there are no other
changes in v0.5.0 that are required at this time.