### PR TITLE
update NextCloud image version to v0.2.4

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -61,7 +61,7 @@
 
       - name: "RDSS Arkivum NextCloud"
         repo: "https://github.com/JiscRDSS/rdss-arkivum-nextcloud"
-        version: "v0.2.3"
+        version: "v0.2.4"
         dest: "./src/rdss-arkivum-nextcloud"
         make_target: "build-files-move-app"
         images:


### PR DESCRIPTION
Updates the playbook to use `v0.2.4` of NextCloud. This depends on https://github.com/JiscRDSS/rdss-arkivum-nextcloud/pull/13 being approved and released as `v0.2.4` first.