### PR TITLE
update playbook for v0.5.4

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -61,7 +61,7 @@
 
       - name: "RDSS Arkivum NextCloud"
         repo: "https://github.com/JiscRDSS/rdss-arkivum-nextcloud"
-        version: "v0.2.4"
+        version: "v0.2.5"
         dest: "./src/rdss-arkivum-nextcloud"
         make_target: "build-files-move-app"
         images:

--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -106,10 +106,11 @@
         # Ignore false ANSIBLE0016 claiming this task should be a handler
         - skip_ansible_lint
 
+    # Don't tag as 'latest' if version contains 'rc' or rdss_version does
     - name: "Build and tag images"
       command: "docker build
         -t {{ item.1.name }}:{{ item.0.item.version | regex_replace('/', '_')  | truncate(128, True)}}
-        -t {{ item.1.name }}:latest
+        {{ '-t ' + item.1.name + ':latest' if 'rc' not in item.0.item.version and 'rc' not in rdss_version else '' }}
         --build-arg ARCHIVEMATICA_VERSION={{ rdss_version }}
         --build-arg AGENT_CODE={{ rdss_version }}
         -f {{ item.1.dockerfile }} ."


### PR DESCRIPTION
This pull request includes two changes:

1. Update the NextCloud version to v0.2.5
1. Only tag images as `latest` if the version of the image or the `rdss_version` is not a release candidate (i.e. does not contain "rc" in the version string).

The latter of these was suggested because some production deployments are configured to use `latest` versions of the Docker images, rather than specific versions, so if this tag is updated with an `rc` version then a redeployment in production could inadvertently deploy an update.

@LondonAppDev are you able to confirm that this change meets your requirements for the `latest` tag?