### PR TITLE
Compose: fits to mount sharedDir with rw perms

### DIFF
--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -99,7 +99,7 @@ services:
     expose:
       - "2113"
     volumes:
-      - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:ro"
+      - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"
 
   clamavd:
     image: "artefactual/clamav:latest"


### PR DESCRIPTION
Otherwise the job "Characterize and extract metadata on submission
documentation" fails (group "Process submission documentation) with the
following error:

```
java.io.FileNotFoundException: /var/archivematica/sharedDirectory/tmp/fits.haEnq9/fits.xml (Read-only file system)
	at java.io.FileOutputStream.open(Native Method)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:221)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:110)
	at edu.harvard.hul.ois.fits.Fits.outputResults(Fits.java:320)
	at edu.harvard.hul.ois.fits.Fits.main(Fits.java:226)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at com.martiansoftware.nailgun.NGSession.run(NGSession.java:280)

Command FITS failed with exit status 131; stderr: java.io.FileNotFoundException: /var/archivematica/sharedDirectory/tmp/fits.haEnq9/fits.xml (Read-only file system)
	at java.io.FileOutputStream.open(Native Method)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:221)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:110)
	at edu.harvard.hul.ois.fits.Fits.outputResults(Fits.java:320)
	at edu.harvard.hul.ois.fits.Fits.main(Fits.java:226)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at com.martiansoftware.nailgun.NGSession.run(NGSession.java:280)
```