### PR TITLE
Add reset-processing-configs target to Makefiles

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -56,7 +56,7 @@ export VERSION
 
 all: destroy build create-secrets up bootstrap list
 
-bootstrap create-secrets:
+bootstrap create-secrets reset-processing-configs:
 	$(foreach DIR, $(COMPOSE_DIRS), $(MAKE) -C $(DIR) $@ ;)
 
 build clean destroy:

--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -119,7 +119,20 @@ destroy:
 list:
 	docker-compose ps
 
+reset-processing-configs:
+	# Remove the builtin processing configs so the originals can be restored when mcp server restarts
+	docker-compose run --rm --no-deps \
+		--user root \
+		--entrypoint rm \
+		--workdir /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs/ \
+			archivematica-mcp-server \
+				-f automatedProcessingMCP.xml defaultProcessingMCP.xml;
+
+ifeq ($(RESET_PROCESSING_CONFIG), true)
+restart-mcp-services: reset-processing-configs
+else
 restart-mcp-services:
+endif
 	docker-compose restart archivematica-mcp-server archivematica-mcp-client
 
 up: build

--- a/compose/qa/Makefile
+++ b/compose/qa/Makefile
@@ -112,8 +112,21 @@ destroy:
 list:
 	docker-compose ps
 
+ifeq ($(RESET_PROCESSING_CONFIG), true)
+restart-mcp-services: reset-processing-configs
+else
 restart-mcp-services:
+endif
 	docker-compose restart archivematica-mcp-server archivematica-mcp-client
+
+reset-processing-configs:
+	# Remove the builtin processing configs so the originals can be restored when mcp server restarts
+	docker-compose run --rm --no-deps \
+		--user root \
+		--entrypoint rm \
+		--workdir /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs/ \
+			archivematica-mcp-server \
+				-f automatedProcessingMCP.xml defaultProcessingMCP.xml;
 
 up: build
 	$(foreach DIR, $(COMPOSE_DIRS), docker-compose up -d ;)


### PR DESCRIPTION
This deletes the builtin processing configs (automated and default)
so that MCP Server can recreate from the original configs when restarted.

Called before restart-mcp-services, if `RESET_PROCESSING_CONFIG` env var
is set to true. It is defined as a target in its own right in case there
is a need to call it manually.

See also https://github.com/JiscRDSS/archivematica/pull/67