### PR TITLE
deployment: use docker-compose v1.17.0 by default

### DIFF
--- a/aws/machine/lib/lib-docker.sh
+++ b/aws/machine/lib/lib-docker.sh
@@ -42,7 +42,8 @@ check_dockerhost_dependencies()
             s3fs \
             software-properties-common && \
         sudo usermod -a -G docker ubuntu && \
-        sudo -H pip install -U pip docker-compose"
+        sudo -H pip install -U pip && \
+        sudo -H pip install docker-compose==${DOCKER_COMPOSE_VERSION:-1.17.0}"
 }
 
 # Checks, and if necessary creates, a registry on the remote Docker host.


### PR DESCRIPTION
This is because versions > 1.19.0 have a change in their behaviour (introduced in 1.19.0) that means that our use of docker-compose to exec a mysql command to test mysql connectivity during the bootstrap doesn't return the right status, so the deployment gets stuck waiting for the
mysql service to become ready.

There is also a different problem with v1.18.0, which attempts to use a newer version of the Docker API, which means that `docker-compose build` fails, hence why v1.17.0 is used here.

Fixes issue #191.