### PR TITLE
compose: use registry and env var for shib-sp-proxy image version

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -37,6 +37,9 @@ MINIKINE_VERSION=latest
 RDSS_CHANADAPTER_VERSION=latest
 RDSS_MSGCREATOR_VERSION=latest
 
+# Shibboleth SP Proxy
+SHIB_SPPROXY_VERSION=latest
+
 ## Archivematica ##############################################################
 
 # Whether you want Gunicorn to reload the code automatically.

--- a/compose/docker-compose.am-shib.yml
+++ b/compose/docker-compose.am-shib.yml
@@ -37,7 +37,7 @@ services:
 
   # Enforces Shibboleth authentication in front of our AM nginx proxy
   shib-sp-proxy:
-    image: "rdss-archivematica-shib-sp-proxy"
+    image: "${REGISTRY}rdss-archivematica-shib-sp-proxy:${SHIB_SPPROXY_VERSION}"
     #build:
     #  context: "${VOL_BASE}/../src/rdss-archivematica-shib-sp-proxy/"
     networks:


### PR DESCRIPTION
This is so we can configure where we get the image from and with what version.

Based on @mamedin's work in the `dev/nextcloud-shibboleth-mamedin` branch.