### PR TITLE
Compose: fix nextcloud config

### DIFF
--- a/compose/docker-compose.am-shib.yml
+++ b/compose/docker-compose.am-shib.yml
@@ -88,7 +88,6 @@ services:
     environment:
       # Proxy settings
       HTTP_PROTOCOL: "https"
-      NEXTCLOUD_HOST: "nextcloud.${DOMAIN_NAME}"
       PROXY_HOST: "nginx-ssl"
       # Shibboleth
       SHIBBOLETH_AUTHENTICATION: "true"

--- a/compose/docker-compose.am-shib.yml
+++ b/compose/docker-compose.am-shib.yml
@@ -88,6 +88,8 @@ services:
     environment:
       # Proxy settings
       HTTP_PROTOCOL: "https"
+      NEXTCLOUD_HOST: "nextcloud.${DOMAIN_NAME}"
+      NEXTCLOUD_PORT: "${NEXTCLOUD_EXTERNAL_SSL_PORT}"
       PROXY_HOST: "nginx-ssl"
       # Shibboleth
       SHIBBOLETH_AUTHENTICATION: "true"

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -367,6 +367,7 @@ services:
         interactive-transfer:/mnt/am-ss-default-location-data/interactive \
         s3-jisc-test-research:/mnt/jisc-test-research-data"
       NEXTCLOUD_HOST: "nextcloud.${DOMAIN_NAME}"
+      NEXTCLOUD_PORT: "8888"
     volumes:
       # Nextcloud app volumes
       - "nextcloud_data:/var/lib/nextcloud"

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -366,6 +366,7 @@ services:
         automated-transfer:/mnt/am-ss-default-location-data/automated \
         interactive-transfer:/mnt/am-ss-default-location-data/interactive \
         s3-jisc-test-research:/mnt/jisc-test-research-data"
+      NEXTCLOUD_HOST: "nextcloud.${DOMAIN_NAME}"
     volumes:
       # Nextcloud app volumes
       - "nextcloud_data:/var/lib/nextcloud"


### PR DESCRIPTION
There are a couple of things to do with the NextCloud config in our Compose files that needs fixing.

1. We need to set `NEXTCLOUD_HOST` in our `qa` config, not just `am-shib`, because otherwise the default `nextcloud.example.ac.uk` is used as the host name in non-Shibboleth deployments.
1. We need to set the [newly added](https://github.com/JiscRDSS/rdss-arkivum-nextcloud/pull/23) `NEXTCLOUD_PORT` environment variable so that the port number is correct when building NextCloud URLs.