### PR TITLE
Update image versions for v0.6.0-rc8

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -23,7 +23,7 @@
 
       - name: "Archivematica (JiscRDSS fork)"
         repo: "https://github.com/JiscRDSS/archivematica"
-        version: "v0.6.4"
+        version: "v0.6.5"
         dest: "./src/archivematica"
         images:
           - name: "{{ registry }}archivematica-dashboard"
@@ -65,7 +65,7 @@
 
       - name: "RDSS Arkivum NextCloud"
         repo: "https://github.com/JiscRDSS/rdss-arkivum-nextcloud"
-        version: "v0.4.0"
+        version: "v0.5.0"
         dest: "./src/rdss-arkivum-nextcloud"
         make_target: "build-apps"
         images:


### PR DESCRIPTION
This pull request updates the following image versions:

* Archivematica to [v0.6.5](https://github.com/JiscRDSS/archivematica/releases/tag/v0.6.5)
* NextCloud to [v0.5.0](https://github.com/JiscRDSS/rdss-arkivum-nextcloud/releases/tag/v0.5.0)

Other image versions remain unchanged.

This change is targeted towards v0.6.0-rc8 release.