### PR TITLE
Improvement: make Compose work in multi-user environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - python -myamllint -f parsable *-playbook.yml
   - ansible-lint -p *-playbook.yml
   # Validate the quickstart shell scripts
-  - shellcheck quickstart
+  - shellcheck -f gcc quickstart
   # Validate the shell scripts for aws/machine
   - pushd aws/machine ; find . \( -name \*.sh -or -name \*.bash \) -exec shellcheck -x -f gcc {} + ; popd
   # TODO Add additional validation/build steps here

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ script:
   # Validate our Ansible playbooks
   - python -myamllint -f parsable *-playbook.yml
   - ansible-lint -p *-playbook.yml
+  # Validate the quickstart shell scripts
+  - shellcheck quickstart
   # Validate the shell scripts for aws/machine
   - pushd aws/machine ; find . \( -name \*.sh -or -name \*.bash \) -exec shellcheck -x -f gcc {} + ; popd
   # TODO Add additional validation/build steps here

--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 Integration repo for the RDSS fork of Archivematica.
 
+## Development Quick Start
+
+For development, you can deploy docker containers into your local Docker environment. Most users will be running as the single user on their system, but multi-user deployments are supported too.
+
+There's now a handy `quickstart` script to get you up and running as quickly as possible. This script will automatically create a unique namespace for each user, as well as selecting ports that are not already in use.
+
+To start up all the required services, volumes and containers etc, use:
+
+	$ ./quickstart start
+
+Once built, you can then check the status with:
+
+	$ ./quickstart status
+
+If you want to terminate your deployment, use:
+
+	$ ./quickstart shutdown
+
+If you no longer want your deployment at all, use:
+
+	$ ./quickstart destroy
+
+This will wipe all persistent data for your deployment and remove any associated built images from your system. Any other deployments on the same Docker environment will remain untouched.
+
+For more advanced usage, see below.
+
 ## Usage
 
 This project uses a Makefile to drive the build. Run `make help` to see a list

--- a/compose/.env
+++ b/compose/.env
@@ -115,3 +115,12 @@ IDP_EXTERNAL_PORT=4443
 # interfaces.
 NGINX_EXTERNAL_IP=0.0.0.0
 
+## Registry ###################################################################
+
+# The port to run a Docker registry on. Change if running multiple registries
+# on the same machine, e.g. in multi-user development environment.
+REGISTRY_PORT=5000
+
+# The port on which to run the frontend for the Docker registry. Change if the
+# default port is already in use.
+REGISTRY_FRONTEND_PORT=8000

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -8,18 +8,21 @@ COMPOSE_DIRS ?= $(ENV)
 
 BASE_DIR ?= ${CURDIR}
 
+COMPOSE_PROJECT_NAME ?= rdss
+
 # Paths for Docker named volumes
-AM_AUTOTOOLS_DATA ?= /tmp/rdss/am-autotools-data
-AM_PIPELINE_DATA ?= /tmp/rdss/am-pipeline-data
-ARK_STORAGE_DATA ?= /tmp/rdss/arkivum-storage
-ELASTICSEARCH_DATA ?= /tmp/rdss/elasticsearch-data
-JISC_TEST_DATA ?= /tmp/rdss/jisc-test-data
-MINIO_EXPORT_DATA ?= /tmp/rdss/minio-export-data
-MYSQL_DATA ?= /tmp/rdss/mysql-data
-NEXTCLOUD_DATA ?= /tmp/rdss/nextcloud-data
-NEXTCLOUD_THEMES ?= /tmp/rdss/nextcloud-themes
-SS_LOCATION_DATA ?= /tmp/rdss/am-ss-location-data
-SS_STAGING_DATA ?= /tmp/rdss/am-ss-staging-data
+DATA_DIR ?= /tmp/$(COMPOSE_PROJECT_NAME)
+AM_AUTOTOOLS_DATA ?= $(DATA_DIR)/am-autotools-data
+AM_PIPELINE_DATA ?= $(DATA_DIR)/am-pipeline-data
+ARK_STORAGE_DATA ?= $(DATA_DIR)/arkivum-storage
+ELASTICSEARCH_DATA ?= $(DATA_DIR)/elasticsearch-data
+JISC_TEST_DATA ?= $(DATA_DIR)/jisc-test-data
+MINIO_EXPORT_DATA ?= $(DATA_DIR)/minio-export-data
+MYSQL_DATA ?= $(DATA_DIR)/mysql-data
+NEXTCLOUD_DATA ?= $(DATA_DIR)/nextcloud-data
+NEXTCLOUD_THEMES ?= $(DATA_DIR)/nextcloud-themes
+SS_LOCATION_DATA ?= $(DATA_DIR)/am-ss-location-data
+SS_STAGING_DATA ?= $(DATA_DIR)/am-ss-staging-data
 
 # Do we want to include any shibboleth services?
 SHIBBOLETH_IDP ?= local
@@ -74,45 +77,45 @@ create-volumes:
 	# Create Archivematica named volumes
 	@mkdir -p $(AM_AUTOTOOLS_DATA)
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(AM_AUTOTOOLS_DATA) rdss_am-autotools-data
+		--opt device=$(AM_AUTOTOOLS_DATA) $(COMPOSE_PROJECT_NAME)_am-autotools-data
 	@mkdir -p ${AM_PIPELINE_DATA}
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(AM_PIPELINE_DATA) rdss_am-pipeline-data
+		--opt device=$(AM_PIPELINE_DATA) $(COMPOSE_PROJECT_NAME)_am-pipeline-data
 	@mkdir -p ${SS_LOCATION_DATA}/automated ${SS_LOCATION_DATA}/interactive
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(SS_LOCATION_DATA) rdss_am-ss-location-data
+		--opt device=$(SS_LOCATION_DATA) $(COMPOSE_PROJECT_NAME)_am-ss-location-data
 	@mkdir -p $(SS_STAGING_DATA)
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(SS_STAGING_DATA) rdss_am-ss-staging-data
+		--opt device=$(SS_STAGING_DATA) $(COMPOSE_PROJECT_NAME)_am-ss-staging-data
 	# Ensure Archivematica dirs are owned by archivematica (333)
 	@chown -R 333:333 $(AM_PIPELINE_DATA) $(SS_LOCATION_DATA) $(SS_STAGING_DATA)
 	@chmod -R a=rwX,+t $(SS_LOCATION_DATA)
 	# Create Arkivum named volumes
 	@mkdir -p $(ARK_STORAGE_DATA)/aipingest
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(ARK_STORAGE_DATA) rdss_arkivum-storage
+		--opt device=$(ARK_STORAGE_DATA) $(COMPOSE_PROJECT_NAME)_arkivum-storage
 	# Create ElasticSearch named volume
 	@mkdir -p $(ELASTICSEARCH_DATA)
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(ELASTICSEARCH_DATA) rdss_elasticsearch-data
+		--opt device=$(ELASTICSEARCH_DATA) $(COMPOSE_PROJECT_NAME)_elasticsearch-data
 	# Create Jisc named volumes
 	@mkdir -p $(JISC_TEST_DATA)
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(JISC_TEST_DATA) rdss_jisc-test-research-data
+		--opt device=$(JISC_TEST_DATA) $(COMPOSE_PROJECT_NAME)_jisc-test-research-data
 	# Create MINIO named volume
 	@mkdir -p $(MINIO_EXPORT_DATA)
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(MINIO_EXPORT_DATA) rdss_minio_export_data
+		--opt device=$(MINIO_EXPORT_DATA) $(COMPOSE_PROJECT_NAME)_minio_export_data
 	# Create MySQL named volume
 	@mkdir -p $(MYSQL_DATA)
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(MYSQL_DATA) rdss_mysql_data
+		--opt device=$(MYSQL_DATA) $(COMPOSE_PROJECT_NAME)_mysql_data
 	# Create NextCloud named volumes
 	@mkdir -p $(NEXTCLOUD_DATA) $(NEXTCLOUD_THEMES)
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(NEXTCLOUD_DATA) rdss_nextcloud-data
+		--opt device=$(NEXTCLOUD_DATA) $(COMPOSE_PROJECT_NAME)_nextcloud-data
 	@docker volume create --opt type=none --opt o=bind \
-		--opt device=$(NEXTCLOUD_THEMES) rdss_nextcloud-themes
+		--opt device=$(NEXTCLOUD_THEMES) $(COMPOSE_PROJECT_NAME)_nextcloud-themes
 
 destroy-volumes:
 	@echo -n "WARNING! About to delete all data on all volumes! Continue? [yes/no]: " ; \
@@ -120,19 +123,19 @@ destroy-volumes:
 	case "$${yn}" in \
 		[Yy][Ee][Ss] ) \
 			docker volume rm \
-				rdss_am-autotools-data \
-				rdss_am-pipeline-data \
-				rdss_am-ss-location-data \
-				rdss_am-ss-staging-data \
-				rdss_arkivum-storage \
-				rdss_elasticsearch-data \
-				rdss_jisc-test-research-data \
-				rdss_minio_export_data \
-				rdss_mysql_data \
-				rdss_nextcloud-data \
-				rdss_nextcloud-themes && \
+				$(COMPOSE_PROJECT_NAME)_am-autotools-data \
+				$(COMPOSE_PROJECT_NAME)_am-pipeline-data \
+				$(COMPOSE_PROJECT_NAME)_am-ss-location-data \
+				$(COMPOSE_PROJECT_NAME)_am-ss-staging-data \
+				$(COMPOSE_PROJECT_NAME)_arkivum-storage \
+				$(COMPOSE_PROJECT_NAME)_elasticsearch-data \
+				$(COMPOSE_PROJECT_NAME)_jisc-test-research-data \
+				$(COMPOSE_PROJECT_NAME)_minio_export_data \
+				$(COMPOSE_PROJECT_NAME)_mysql_data \
+				$(COMPOSE_PROJECT_NAME)_nextcloud-data \
+				$(COMPOSE_PROJECT_NAME)_nextcloud-themes && \
 				echo "Removed all Docker volumes. " ; \
-			if docker volume list | grep rdss_ >/dev/null ; then \
+			if docker volume list | grep $(COMPOSE_PROJECT_NAME)_ >/dev/null ; then \
 				echo "Cannot remove files: docker volumes still in use." ; \
 				exit ;\
 			else \

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -14,37 +14,37 @@ volumes:
   # filesystems from elsewhere.
   archivematica_autotools_data:
     external:
-      name: "rdss_am-autotools-data"
+      name: "${COMPOSE_PROJECT_NAME}_am-autotools-data"
   archivematica_pipeline_data:
     external:
-      name: "rdss_am-pipeline-data"
+      name: "${COMPOSE_PROJECT_NAME}_am-pipeline-data"
   archivematica_storage_service_location_data:
     external:
-      name: "rdss_am-ss-location-data"
+      name: "${COMPOSE_PROJECT_NAME}_am-ss-location-data"
   archivematica_storage_service_staging_data:
     external:
-      name: "rdss_am-ss-staging-data"
+      name: "${COMPOSE_PROJECT_NAME}_am-ss-staging-data"
   arkivum-storage:
     external:
-      name: "rdss_arkivum-storage"
+      name: "${COMPOSE_PROJECT_NAME}_arkivum-storage"
   elasticsearch_data:
     external:
-      name: "rdss_elasticsearch-data"
+      name: "${COMPOSE_PROJECT_NAME}_elasticsearch-data"
   jisc-test-research-data:
     external:
-      name: "rdss_jisc-test-research-data"
+      name: "${COMPOSE_PROJECT_NAME}_jisc-test-research-data"
   minio_export_data:
     external:
-      name: "rdss_minio_export_data"
+      name: "${COMPOSE_PROJECT_NAME}_minio_export_data"
   mysql_data:
     external:
-      name: "rdss_mysql_data"
+      name: "${COMPOSE_PROJECT_NAME}_mysql_data"
   nextcloud_data:
     external:
-      name: "rdss_nextcloud-data"
+      name: "${COMPOSE_PROJECT_NAME}_nextcloud-data"
   nextcloud_themes:
     external:
-      name: "rdss_nextcloud-themes"
+      name: "${COMPOSE_PROJECT_NAME}_nextcloud-themes"
 
 services:
 
@@ -58,8 +58,6 @@ services:
     volumes:
       - "${VOL_BASE}/dev/etc/minio:/root/.minio"
       - "minio_export_data:/export"
-    ports:
-      - "50500:9000"
     expose:
       - "9000"
 
@@ -376,7 +374,7 @@ services:
       - "arkivum-storage:/mnt/astor/"
       - "jisc-test-research-data:/mnt/jisc-test-research-data"
     ports:
-      - "${NEXTCLOUD_EXTERNAL_IP}:8888:8888"
+      - "${NEXTCLOUD_EXTERNAL_IP}:${NEXTCLOUD_EXTERNAL_PORT}:8888"
     depends_on:
       - "mysql"
       - "redis"

--- a/compose/docker-compose.utils.yml
+++ b/compose/docker-compose.utils.yml
@@ -1,0 +1,48 @@
+---
+
+version: "2"
+
+#
+# Utility services for RDSS docker containers. None of these are required for
+# the main services to function, all of them are convenient and useful to have.
+#
+
+services:
+
+  # Performs garbage collection for Docker, removing unused containers and
+  # images periodically to free up disk and reduce resource usage.
+  gc:
+    image: "docwhat/docker-gc:latest"
+    networks:
+      utils:
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+  # Operates a local registry of Docker images, which we publish to and pull
+  # from.
+  registry:
+    image: "registry:2"
+    networks:
+      utils:
+    ports:
+      - "${REGISTRY_PORT}:5000"
+
+  # Provides a convenient web-based user interface to the Docker image registry
+  # so that it's easier to determine what images are published.
+  registry-frontend:
+    image: "konradkleine/docker-registry-frontend:v2"
+    networks:
+      utils:
+    environment:
+      ENV_DOCKER_REGISTRY_HOST: "registry"
+      ENV_DOCKER_REGISTRY_PORT: "5000"
+    ports:
+      - "${REGISTRY_FRONTEND_PORT}:80"
+    depends_on:
+      - "registry"
+
+networks:
+  # Use a separate network to prevent these services from being pulled down
+  # during a `make destroy`.
+  utils:
+    driver: "bridge"

--- a/quickstart
+++ b/quickstart
@@ -1,0 +1,250 @@
+#!/bin/bash
+
+#
+# Quickstart script for RDSSARK Docker Compose
+#
+# Simplifies operation of Docker Compose services to get newcomers going as
+# quickly as possible.
+#
+# Usage: quickstart <start|status|shutdown|destroy>
+# Commands:
+#  * start     - starts all the necessary Docker Compose services
+#  * status    - shows the status of Docker Compose services
+#  * shutdown  - stops and destroys running Docker Compose services
+#  * destroy   - removes all images and destroys persisted storage locations
+#
+
+# The file to load our context from. This includes settings like what the
+# "project name" is, and what ports we want to use.
+CONTEXT_FILE="${CONTEXT_FILE:-./.quickstart.ctx}"
+
+check_sudo()
+{
+    # Check the user is in the sudo group
+    if id -Gn | grep sudo >/dev/null ; then
+        # Only ask if the user isn't already authenticated
+        if ! sudo -n true >/dev/null 2>&1 ; then
+            echo "This script creates folders owned by a different user, which requires sudo."
+            sudo true >/dev/null
+        fi
+    else
+        echo "FATAL! You must have sudo rights to run this."
+        exit 1
+    fi
+}
+
+deploy_services()
+{
+    # Create our registry
+    pushd compose >/dev/null \
+        && docker-compose -f docker-compose.utils.yml up -d
+    popd >/dev/null
+    # Build our images and publish to our registry
+    make publish REGISTRY="localhost:${REGISTRY_PORT}/"
+    # Create storage volumes and bring up our service containers
+    pushd compose >/dev/null \
+        && sudo make create-volumes \
+            COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}" \
+        && make all REGISTRY="localhost:${REGISTRY_PORT}/" \
+        && print_docker_services \
+        && echo "Deployment complete." \
+        && echo
+    popd >/dev/null
+}
+
+destroy_context()
+{
+    rm -Rf "${CONTEXT_FILE}"
+}
+
+destroy()
+{
+    # Load our context
+    get_context
+
+    # Destroy all volumes and shutdown util containers
+    pushd compose \
+        && sudo make destroy-volumes \
+            COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}" \
+        && docker-compose -f docker-compose.utils.yml down --volumes
+    popd
+
+    # Destroy the context
+    destroy_context
+}
+
+get_context()
+{
+    if [ ! -f "${CONTEXT_FILE}" ] ; then
+        # Context doesn't exist, define and save to file
+        cat  << EOF > "${CONTEXT_FILE}"
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(id -un)rdss}"
+export NEXTCLOUD_EXTERNAL_PORT="$(get_free_port "${NEXTCLOUD_EXTERNAL_PORT:-8888}")"
+export REGISTRY_PORT="$(get_free_port "${REGISTRY_PORT:-5000}")"
+export REGISTRY_FRONTEND_PORT="$(get_free_port "${REGISTRY_FRONTEND_PORT:-8000}")"
+EOF
+    fi
+    # Load the context from file
+    source "${CONTEXT_FILE}"
+}
+
+get_free_port()
+{
+    # Get the next free port based on the given port. If the given port is
+    # available then it will be used, otherwise we increment until we find one
+    # that is.
+    local port="$1"
+    while [ "$(netstat -tanp 2>/dev/null | grep "${port}")" != "" ] ; do
+        port="$((port + 1))"
+    done
+    echo -n "${port}"
+}
+
+get_service_port()
+{
+    local -r service="$1"
+    local -r private_port="$2"
+    local -r docker_args="$3"
+    # shellcheck disable=SC2086
+    docker-compose ${docker_args} port "${service}" "${private_port}" 2>/dev/null
+}
+
+print_docker_services()
+{
+    local -r am_dash_port="$(get_service_port nginx 80)"
+    local -r am_ss_port="$(get_service_port nginx 8000)"
+    local -r nc_port="$(get_service_port nextcloud 8888)"
+    local -r reg_port="$(get_service_port registry 5000 '-f docker-compose.utils.yml')"
+    local -r reg_ui_port="$(get_service_port registry-frontend 80 '-f docker-compose.utils.yml')"
+    echo
+    echo "AVAILABLE SERVICES:"
+    echo
+    local service_count=0
+    if [ "${reg_port}" != "" ] ; then
+        service_count=$((service_count + 1))
+        echo "Docker Registry:                localhost:${reg_port#*:}/"
+    fi
+    if [ "${reg_ui_port}" != "" ] ; then
+        service_count=$((service_count + 1))
+        echo "Docker Registry UI:             http://${reg_ui_port}/"
+    fi
+    if [ "${am_dash_port}" != "" ] ; then
+        service_count=$((service_count + 1))
+        echo "Archivematica Dashboard:        http://${am_dash_port}/"
+    fi
+    if [ "${am_ss_port}" != "" ] ; then
+        service_count=$((service_count + 1))
+        echo "Archivematica Storage Service:  http://${am_ss_port}/"
+    fi
+    if [ "${nc_port}" != "" ] ; then
+        service_count=$((service_count + 1))
+        echo "NextCloud:                      http://${nc_port}/"
+    fi
+    if [ ${service_count} -eq 0 ] ; then
+        echo "No services deployed."
+    fi
+    echo
+}
+
+shutdown()
+{
+    # Load our context
+    get_context
+
+    # Shutdown the main containers
+    pushd compose >/dev/null \
+        && make destroy COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}"
+    popd >/dev/null
+}
+
+start() {
+
+    # The `create-volumes` stage requires sudo rights to change the ownership of
+    # created directories. Ask for sudo here to create session so user doesn't
+    # have to wait to be prompted midway through the process.
+    check_sudo
+
+    # Load our context
+    get_context
+
+    # Echo context info and wait for user confirmation before continuing
+    echo "This will deploy a new RDSSARK environment with Archivematica and NextCloud."
+    echo
+    echo "The following settings will be used:"
+    echo
+    echo "Deployment Name:    ${COMPOSE_PROJECT_NAME}"
+    echo "Docker Registry:    localhost:${REGISTRY_PORT}/"
+    echo "Docker Registry UI: http://localhost:${REGISTRY_FRONTEND_PORT}/"
+    echo
+    echo "Ports for Archivematica and NextCloud will be reported after deployment."
+    echo
+    echo -n "Do you wish to continue? [yes/no]: "
+    read yn
+    case "${yn}" in
+        [Yy][Ee][Ss] )
+            # Go ahead and deploy the docker services
+            deploy_services
+            ;;
+        [Nn][Oo] )
+            # Cancel deployment
+            echo "Cancelled on user request."
+            exit 0
+            ;;
+        *)
+            echo "Invalid answer, must be 'yes' or 'no'."
+            ;;
+    esac
+}
+
+status()
+{
+    # Load our context
+    get_context
+
+    # List current containers
+    pushd compose >/dev/null \
+        && echo \
+        && echo '------------------------------------------------------------' \
+        && echo "Deployment details for '${COMPOSE_PROJECT_NAME}'" \
+        && echo '------------------------------------------------------------' \
+        && echo \
+        && echo "DOCKER CONTAINERS:" \
+        && echo \
+        && docker-compose ps \
+        && print_docker_services
+    popd >/dev/null
+}
+
+usage()
+{
+    echo "$(basename "${0}") <destroy|shutdown|status|start>"
+    echo "Commands:"
+    echo "  destroy    Removes all images and destroys persisted storage locations"
+    echo "  shutdown   Stops and destroys running Docker Compose services"
+    echo "  start      Starts all the necessary Docker Compose services"
+    echo "  status     Shows the status of Docker Compose services"
+}
+
+main()
+{
+    local -r command="$1"
+    case "${command}" in
+        destroy)
+            shutdown && destroy
+            ;;
+        shutdown)
+            shutdown
+            ;;
+        status)
+            status
+            ;;
+        start)
+            start
+            ;;
+        *)
+            usage
+            ;;
+    esac
+}
+
+main "$@"

--- a/quickstart
+++ b/quickstart
@@ -14,6 +14,12 @@
 #  * destroy   - removes all images and destroys persisted storage locations
 #
 
+# Directory where this script is stored
+SCRIPT_DIR="$( cd "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" && pwd )"
+
+# Directory where our Docker compose config is located
+COMPOSE_DIR="${SCRIPT_DIR}/compose"
+
 # The file to load our context from. This includes settings like what the
 # "project name" is, and what ports we want to use.
 CONTEXT_FILE="${CONTEXT_FILE:-./.quickstart.ctx}"
@@ -35,21 +41,29 @@ check_sudo()
 
 deploy_services()
 {
-    # Create our registry
-    pushd compose >/dev/null \
-        && docker-compose -f docker-compose.utils.yml up -d
-    popd >/dev/null
+    if pushd "${COMPOSE_DIR}" >/dev/null ; then
+        # Create our registry
+        docker-compose -f docker-compose.utils.yml up -d
+        if ! popd >/dev/null ; then
+            # Should never happen but keeps Shellcheck happy
+            echo "FATAL! deploy_services() failed to popd!" && exit 1
+        fi
+    fi
     # Build our images and publish to our registry
     make publish REGISTRY="localhost:${REGISTRY_PORT}/"
     # Create storage volumes and bring up our service containers
-    pushd compose >/dev/null \
-        && sudo make create-volumes \
-            COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}" \
+    if pushd "${COMPOSE_DIR}" >/dev/null ; then
+        sudo make create-volumes \
+             COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}" \
         && make all REGISTRY="localhost:${REGISTRY_PORT}/" \
         && print_docker_services \
         && echo "Deployment complete." \
         && echo
-    popd >/dev/null
+        if ! popd >/dev/null ; then
+            # Should never happen but keeps Shellcheck happy
+            echo "FATAL! deploy_services() failed to popd (2)!" && exit 1
+        fi
+    fi
 }
 
 destroy_context()
@@ -63,11 +77,15 @@ destroy()
     get_context
 
     # Destroy all volumes and shutdown util containers
-    pushd compose \
-        && sudo make destroy-volumes \
+    if pushd "${COMPOSE_DIR}" >/dev/null ; then
+        sudo make destroy-volumes \
             COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}" \
         && docker-compose -f docker-compose.utils.yml down --volumes
-    popd
+        if ! popd >/dev/null ; then
+            # Should never happen but keeps Shellcheck happy
+            echo "FATAL! destroy() failed to return to popd!" && exit 1
+        fi
+    fi
 
     # Destroy the context
     destroy_context
@@ -85,6 +103,7 @@ export REGISTRY_FRONTEND_PORT="$(get_free_port "${REGISTRY_FRONTEND_PORT:-8000}"
 EOF
     fi
     # Load the context from file
+    # shellcheck source=/dev/null
     source "${CONTEXT_FILE}"
 }
 
@@ -152,9 +171,13 @@ shutdown()
     get_context
 
     # Shutdown the main containers
-    pushd compose >/dev/null \
-        && make destroy COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}"
-    popd >/dev/null
+    if pushd "${COMPOSE_DIR}" >/dev/null ; then
+        make destroy COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}"
+        if ! popd >/dev/null ; then
+            # Should never happen but keeps Shellcheck happy
+            echo "FATAL! shutdown() failed to popd!" && exit 1
+        fi
+    fi
 }
 
 start() {
@@ -179,7 +202,7 @@ start() {
     echo "Ports for Archivematica and NextCloud will be reported after deployment."
     echo
     echo -n "Do you wish to continue? [yes/no]: "
-    read yn
+    read -r yn
     case "${yn}" in
         [Yy][Ee][Ss] )
             # Go ahead and deploy the docker services
@@ -202,8 +225,8 @@ status()
     get_context
 
     # List current containers
-    pushd compose >/dev/null \
-        && echo \
+    if pushd "${COMPOSE_DIR}" >/dev/null ; then
+        echo \
         && echo '------------------------------------------------------------' \
         && echo "Deployment details for '${COMPOSE_PROJECT_NAME}'" \
         && echo '------------------------------------------------------------' \
@@ -212,7 +235,11 @@ status()
         && echo \
         && docker-compose ps \
         && print_docker_services
-    popd >/dev/null
+        if ! popd >/dev/null ; then
+            # Should never happen but keeps Shellcheck happy
+            echo "FATAL! status() failed to popd!" && exit 1
+        fi
+    fi
 }
 
 usage()


### PR DESCRIPTION
With new people coming onto the project, it's become necessary for us to run different deployments simultaneously on the same Docker host.

In trying this, there were a couple of things preventing this from working, in particular the lack of automatic namespacing of deployments (all used a project name of `rdss`), difficult-to-override storage locations, and use of specific ports for exposing services, which by default was always the same (port 8888 for NextCloud, for example). The first commit therefore fixes this, allowing multiple deployments to the same Docker host to be possible.

However, though possible, it is still too difficult to achieve a new deployment, especially for novice users who aren't familiar with Docker or our applications. Even just setting up a registry in a consistent way can be too difficult. So, the second commit adds a new `docker-compose.utils.yml` config to the mix, which defines services for a Docker registry, a frontend for this registry, and a garbage collector to keep the Docker installation tidy.

Lastly, to avoid new users having to grapple with the vast number of environment variables they can override, I've added the `quickstart` script, which brings up a working service set with a single command, and allows it to be shutdown and cleared down with similarly simple commands. The main README has been updated to include instructions for this usage.

The quickstart tool doesn't currently allow options for deploying with Shibboleth or building from the dev config rather than qa, but this could be added with a bit of extra efforts using `getopt`, if required.

It's possible that this could also be useful for streamlining the deployment of uat and prod environments too, although for the moment it's intended purely for development, as it will need hardening and battle testing before being used more seriously.