### PR TITLE
compose: don't set NextCloud env vars in qa config

### DIFF
--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -366,8 +366,6 @@ services:
         automated-transfer:/mnt/am-ss-default-location-data/automated \
         interactive-transfer:/mnt/am-ss-default-location-data/interactive \
         s3-jisc-test-research:/mnt/jisc-test-research-data"
-      NEXTCLOUD_HOST: "nextcloud.${DOMAIN_NAME}"
-      NEXTCLOUD_PORT: "8888"
     volumes:
       # Nextcloud app volumes
       - "nextcloud_data:/var/lib/nextcloud"


### PR DESCRIPTION
We don't want to set the `NEXTCLOUD_HOST` or `NEXTCLOUD_PORT` env vars in the  `qa` config because NextCloud is able to detect the correct values itself.

The only time we need to use these is in the `am-shib` config, as there NextCloud is behind the SSL proxy, so we need to override the auto-detected values.

See also JiscRDSS/rdss-arkivum-nextcloud#27 which removes the defaults that are currently used if the environment variables aren't set.