### PR TITLE
Update NextCloud to v0.5.1

### DIFF
--- a/publish-images-playbook.yml
+++ b/publish-images-playbook.yml
@@ -65,7 +65,7 @@
 
       - name: "RDSS Arkivum NextCloud"
         repo: "https://github.com/JiscRDSS/rdss-arkivum-nextcloud"
-        version: "v0.5.0"
+        version: "v0.5.1"
         dest: "./src/rdss-arkivum-nextcloud"
         make_target: "build-apps"
         images:


### PR DESCRIPTION
We need to update the NextCloud image to version 0.5.1 to take advantage of new default behaviour now that we're not setting the env vars in our `qa` config (see #210).