### PR TITLE
deployment: increase default root size for dockerhost instance

### DIFF
--- a/aws/machine/README.md
+++ b/aws/machine/README.md
@@ -70,7 +70,7 @@ Before use, you will need to fill out the [configuration template](etc/deploymen
 ### Docker Host Parameters
 
 1. `DOCKERHOST_INSTANCE_TYPE`: The EC2 instance type to use for the Docker host. Defaults to `t2.medium`, which is the minimum required for all containers to build and run.
-1. `DOCKERHOST_ROOT_SIZE`: The size of the root partition for the Docker host, in gigabytes. Defaults to 16, which is the minimum viable for running all containers.
+1. `DOCKERHOST_ROOT_SIZE`: The size of the root partition for the Docker host, in gigabytes. Defaults to 40, which is the minimum viable for running all containers.
 
 ### NextCloud Parameters
 

--- a/aws/machine/etc/deployment.conf.template
+++ b/aws/machine/etc/deployment.conf.template
@@ -80,9 +80,9 @@ DOCKERHOST_INSTANCE=${DOCKERHOST_INSTANCE:-"${PROJECT_ID}-${ENVIRONMENT}-dockerh
 DOCKERHOST_INSTANCE_TYPE=${DOCKERHOST_INSTANCE_TYPE:-"t2.medium"}
 
 # The size of the root partition for this deployment's Docker host, in
-# gigabytes. Default is 16, which is the minimum viable for running our Docker
+# gigabytes. Default is 40, which is the minimum viable for running our Docker
 # containers.
-DOCKERHOST_ROOT_SIZE=${DOCKERHOST_ROOT_SIZE:-16}
+DOCKERHOST_ROOT_SIZE=${DOCKERHOST_ROOT_SIZE:-40}
 
 # NextCloud ####################################################################
 


### PR DESCRIPTION
Recent changes in our Docker images mean that 16G is no longer enough, so it's now increased to 40G. When I did a test deployment with a bigger volume, the usage on `/` was 17G, so 40G gives us a fair bit of overhead for the future.