### PR TITLE
compose: add environment variables for channel adapter queues

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -148,6 +148,18 @@ RDSS_ADAPTER_KINESIS_ENDPOINT=http://minikine:4567/
 # to false.
 RDSS_ADAPTER_KINESIS_TLS=false
 
+# The name of the queue to post error messages to. Defaults to "error".
+RDSS_ADAPTER_QUEUE_ERROR="error"
+
+# The name of the queue to read input messages from. Defaults to "input".
+RDSS_ADAPTER_QUEUE_INPUT="input"
+
+# The name of the queue to post invalid messages to. Defaults to "invalid".
+RDSS_ADAPTER_QUEUE_INVALID="invalid"
+
+# The name of the queue to post output messages to. Defaults to "output".
+RDSS_ADAPTER_QUEUE_OUTPUT="output"
+
 # The AWS access key to use when accessing S3. Not used for mock service.
 RDSS_ADAPTER_S3_AWS_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
 

--- a/compose/README.md
+++ b/compose/README.md
@@ -264,10 +264,12 @@ The following are the main environment variables that are supported by this buil
 
 There are many more - for the full list see the [compose environment file](.env) and the comments there.
 
-AWS Services
--------------
+Channel Adapter
+-----------------
 
 The RDSS Channel Adapter publisher and consumer require access to AWS services, namely DynamoDB, Kinesis and S3. If these are not available, for example on a local development or QA environment, then mock services will be used instead. However, if you do wish to use real AWS services, the following will be of use.
+
+In addition, the names of the queues to use for a deployment must be specified. For local usage, the defaults are fine, but for real usage they should include the deployment id too.
 
 ### DynamoDB Parameters
 
@@ -286,6 +288,15 @@ The RDSS Channel Adapter publisher and consumer require access to AWS services, 
 | `RDSS_ADAPTER_KINESIS_ENDPOINT` | The endpoint to use for the Kinesis service. Default to using the mock "minikine" service. Set to `''` to use real AWS service. |
 | `RDSS_ADAPTER_KINESIS_TLS` | Whether or not to use TLS encryption when connecting to the Kinesis service. Defaults to `false` but set to `true` if using real AWS. |
 
+### Queue Parameters
+
+| Variable | Description |
+|---|---|
+| `RDSS_ADAPTER_QUEUE_ERROR` | The name of the queue to use for error messages. Default is `error`. |
+| `RDSS_ADAPTER_QUEUE_INPUT` | The name of the queue to use for input messages. Default is `input`. |
+| `RDSS_ADAPTER_QUEUE_INVALID` | The name of the queue to use for invalid messages. Default is `invalid` |
+| `RDSS_ADAPTER_QUEUE_OUTPUT` | The name of the queue to use for output messages. Default is `output`. |
+
 ### S3 Parameters
 
 | Variable | Description |
@@ -295,9 +306,9 @@ The RDSS Channel Adapter publisher and consumer require access to AWS services, 
 | `RDSS_ADAPTER_S3_AWS_SECRET_KEY` | The AWS secret key to use when accessing S3. |
 | `RDSS_ADAPTER_S3_ENDPOINT` | The endpoint to use for the S3 service. Defaults to using the mock "minio" service. |
 
-### Example AWS usage
+### Example AWS Usage
 
-To use the real AWS services, use the following environment variables:
+To use the real AWS services, with custom queues, use the following environment variables:
 
 	export RDSS_ADAPTER_DYNAMODB_ENDPOINT=''
 	export RDSS_ADAPTER_DYNAMODB_TLS='true'
@@ -306,12 +317,18 @@ To use the real AWS services, use the following environment variables:
 	export RDSS_ADAPTER_KINESIS_AWS_REGION="${AWS_REGION}"
 	export RDSS_ADAPTER_KINESIS_ENDPOINT=''
 	export RDSS_ADAPTER_KINESIS_TLS='true'
+	export RDSS_ADAPTER_QUEUE_ERROR="institution_${PROJECT_ID}_error_${ENV}"
+	export RDSS_ADAPTER_QUEUE_INPUT="institution_${PROJECT_ID}_input_${ENV}"
+	export RDSS_ADAPTER_QUEUE_INVALID="institution_${PROJECT_ID}_invalid_${ENV}"
+	export RDSS_ADAPTER_QUEUE_OUTPUT=""institution_${PROJECT_ID}_output_${ENV}"
 	export RDSS_ADAPTER_S3_ENDPOINT=''
 	export RDSS_ADAPTER_S3_AWS_ACCESS_KEY="${AWS_ACCESS_KEY_ID}"
 	export RDSS_ADAPTER_S3_AWS_SECRET_KEY="${AWS_SECRET_ACCESS_KEY}"
 	export RDSS_ADAPTER_S3_AWS_REGION="${AWS_REGION}"
 
-You can then use a command like `make all MOCK_AWS=false` or `docker-compose up` and the exported environment variables will be used to configure the deployed services.
+For Jisc use, the `${PROJECT_ID}` should match the `jisc_id` of the deployment, and `${ENV}` should be one of `dev`, `uat`, or `prod`.
+
+Having exported these variables, you can then use a command like `make all MOCK_AWS=false` or `docker-compose up` and they will be used to configure the deployed services.
 
 Secrets
 --------

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -68,7 +68,7 @@ services:
   rdss-archivematica-msgcreator:
     build:
       context: "../src/qa/rdss-archivematica-msgcreator"
-    entrypoint: "go run main.go -addr=0.0.0.0:8000 -prefix=/msgcreator -kinesis-endpoint='${RDSS_ADAPTER_KINESIS_ENDPOINT}' -kinesis-stream=main -kinesis-region='${RDSS_ADAPTER_KINESIS_AWS_REGION}'-s3-access-key='${RDSS_ADAPTER_S3_AWS_ACCESS_KEY}' -s3-secret-key='${RDSS_ADAPTER_S3_AWS_SECRET_KEY}' -s3-region='${RDSS_ADAPTER_S3_AWS_REGION}' -s3-endpoint='${RDSS_ADAPTER_S3_ENDPOINT}'"
+    entrypoint: "go run main.go -addr=0.0.0.0:8000 -prefix=/msgcreator -kinesis-endpoint='${RDSS_ADAPTER_KINESIS_ENDPOINT}' -kinesis-stream='${RDSS_ADAPTER_QUEUE_INPUT}' -kinesis-region='${RDSS_ADAPTER_KINESIS_AWS_REGION}'-s3-access-key='${RDSS_ADAPTER_S3_AWS_ACCESS_KEY}' -s3-secret-key='${RDSS_ADAPTER_S3_AWS_SECRET_KEY}' -s3-region='${RDSS_ADAPTER_S3_AWS_REGION}' -s3-endpoint='${RDSS_ADAPTER_S3_ENDPOINT}'"
     volumes:
       - "${VOL_BASE}/../src/qa/rdss-archivematica-msgcreator:/go/src/github.com/JiscRDSS/rdss-archivematica-msgcreator"
       

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -235,7 +235,7 @@ services:
       # TODO Replace this with reference to AWS RDS hosted MySQL
       - "mysql"
 
-  # TODO Change this to use AWS servicesfor QA but still use mock for dev
+  # TODO Change this to use AWS services for QA but still use mock for dev
   rdss-archivematica-channel-adapter-consumer:
     image: '${REGISTRY}rdss-archivematica-channel-adapter:${RDSS_CHANADAPTER_VERSION}'
     command: "consumer"
@@ -253,9 +253,9 @@ services:
       RDSS_ARCHIVEMATICA_ADAPTER_S3.ACCESS_KEY: "${RDSS_ADAPTER_S3_AWS_ACCESS_KEY}"
       RDSS_ARCHIVEMATICA_ADAPTER_S3.SECRET_KEY: "${RDSS_ADAPTER_S3_AWS_SECRET_KEY}"
       RDSS_ARCHIVEMATICA_ADAPTER_S3.REGION: "${RDSS_ADAPTER_S3_AWS_REGION}"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.MAIN: "main"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.INVALID: "invalid"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.ERROR: "error"
+      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.MAIN: "${RDSS_ADAPTER_QUEUE_INPUT}"
+      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.INVALID: "${RDSS_ADAPTER_QUEUE_INVALID}"
+      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.ERROR: "${RDSS_ADAPTER_QUEUE_ERROR}"
       RDSS_ARCHIVEMATICA_ADAPTER_BROKER.REPOSITORY.BACKEND: "dynamodb"
       RDSS_ARCHIVEMATICA_ADAPTER_BROKER.REPOSITORY.DYNAMODB_TLS: "${RDSS_ADAPTER_DYNAMODB_TLS}"
       RDSS_ARCHIVEMATICA_ADAPTER_BROKER.REPOSITORY.DYNAMODB_ENDPOINT: "${RDSS_ADAPTER_DYNAMODB_ENDPOINT}"
@@ -275,15 +275,15 @@ services:
     ports:
       - "6060" # See net/http/pprof
 
-  # TODO Change this to use AWS servicesfor QA but still use mock for dev
+  # TODO Change this to use AWS services for QA but still use mock for dev
   rdss-archivematica-channel-adapter-publisher:
     image: '${REGISTRY}rdss-archivematica-channel-adapter:${RDSS_CHANADAPTER_VERSION}'
     command: "publisher"
     environment:
       RDSS_ARCHIVEMATICA_ADAPTER_LOGGING.LEVEL: "debug"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.MAIN: "main"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.INVALID: "invalid"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.ERROR: "error"
+      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.MAIN: "${RDSS_ADAPTER_QUEUE_OUTPUT}"
+      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.INVALID: "${RDSS_ADAPTER_QUEUE_INVALID}"
+      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.ERROR: "${RDSS_ADAPTER_QUEUE_ERROR}"
       RDSS_ARCHIVEMATICA_ADAPTER_BROKER.BACKEND: "kinesis"
       RDSS_ARCHIVEMATICA_ADAPTER_BROKER.KINESIS.TLS: "${RDSS_ADAPTER_KINESIS_TLS}"
       RDSS_ARCHIVEMATICA_ADAPTER_BROKER.KINESIS.ENDPOINT: "${RDSS_ADAPTER_KINESIS_ENDPOINT}"
@@ -298,7 +298,7 @@ services:
   # TODO Change this to use AWS service for QA but still use mock for dev
   rdss-archivematica-msgcreator:
     image: '${REGISTRY}rdss-archivematica-msgcreator:${RDSS_MSGCREATOR_VERSION}'
-    command: "-addr=0.0.0.0:8000 -prefix=/msgcreator -kinesis-endpoint='${RDSS_ADAPTER_KINESIS_ENDPOINT}' -kinesis-stream=main -kinesis-region='${RDSS_ADAPTER_KINESIS_AWS_REGION}' -s3-access-key='${RDSS_ADAPTER_S3_AWS_ACCESS_KEY}' -s3-secret-key='${RDSS_ADAPTER_S3_AWS_SECRET_KEY}' -s3-region=eu-west-2 -s3-endpoint='${RDSS_ADAPTER_S3_ENDPOINT}'"
+    command: "-addr=0.0.0.0:8000 -prefix=/msgcreator -kinesis-endpoint='${RDSS_ADAPTER_KINESIS_ENDPOINT}' -kinesis-stream='${RDSS_ADAPTER_QUEUE_INPUT}' -kinesis-region='${RDSS_ADAPTER_KINESIS_AWS_REGION}' -s3-access-key='${RDSS_ADAPTER_S3_AWS_ACCESS_KEY}' -s3-secret-key='${RDSS_ADAPTER_S3_AWS_SECRET_KEY}' -s3-region='${RDSS_ADAPTER_S3_AWS_REGION}' -s3-endpoint='${RDSS_ADAPTER_S3_ENDPOINT}'"
     expose:
       - "8000"
 


### PR DESCRIPTION
When working with queues in Jisc's Kinesis we will need to set the queue names. This pull request adds new `RDSS_ADAPTER_QUEUE_*` environment variables to make it easier to consistently set the queue names that the consumer and publisher should be using when working with the Kinesis streams.

Note that this assumes there are four streams, not three ("input" and "output", not "main"), so won't work with minikine unless https://github.com/JiscRDSS/rdss-archivematica-channel-adapter/commit/08f6f3a87513609f8a726e85bbbd36dcc378dc7c is included in the built minikine image (which at the moment means building from `master` of rdss-archivematica-channel-adapter rather than a tagged release).