### PR TITLE
compose: fix channel adapter queue config

### DIFF
--- a/compose/.env
+++ b/compose/.env
@@ -149,16 +149,16 @@ RDSS_ADAPTER_KINESIS_ENDPOINT=http://minikine:4567/
 RDSS_ADAPTER_KINESIS_TLS=false
 
 # The name of the queue to post error messages to. Defaults to "error".
-RDSS_ADAPTER_QUEUE_ERROR="error"
+RDSS_ADAPTER_QUEUE_ERROR=error
 
 # The name of the queue to read input messages from. Defaults to "input".
-RDSS_ADAPTER_QUEUE_INPUT="input"
+RDSS_ADAPTER_QUEUE_INPUT=input
 
 # The name of the queue to post invalid messages to. Defaults to "invalid".
-RDSS_ADAPTER_QUEUE_INVALID="invalid"
+RDSS_ADAPTER_QUEUE_INVALID=invalid
 
 # The name of the queue to post output messages to. Defaults to "output".
-RDSS_ADAPTER_QUEUE_OUTPUT="output"
+RDSS_ADAPTER_QUEUE_OUTPUT=output
 
 # The AWS access key to use when accessing S3. Not used for mock service.
 RDSS_ADAPTER_S3_AWS_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE

--- a/compose/docker-compose.mock-aws.qa.yml
+++ b/compose/docker-compose.mock-aws.qa.yml
@@ -19,9 +19,10 @@ services:
   minikine:
     image: '${REGISTRY}minikine:${MINIKINE_VERSION}'
     environment:
-      MINIKINE_STREAM_MAIN: "main"
+      MINIKINE_STREAM_INPUT: "input"
       MINIKINE_STREAM_INVALID: "invalid"
       MINIKINE_STREAM_ERROR: "error"
+      MINIKINE_STREAM_OUTPUT: "output"
       MINIKINE_STREAM_SHARDS: "4"
     expose:
       - "4567"


### PR DESCRIPTION
The default queue names incorrectly had double quotes around them, which were being interpreted as part of the intended queue name, only double quotes aren't legal in stream names.

Also updated minikine config now that the image expects `input` and `output` queues rather than just `main`.