### PR TITLE
compose: Shibboleth and ENV=dev fixes

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -57,7 +57,9 @@ ifeq ("$(ENV)", "dev")
 		COMPOSE_FILE_3 := $(shell realpath ${CURDIR}/docker-compose.mock-aws.qa.yml):$(COMPOSE_FILE_2)
 		override COMPOSE_FILE_2=$(COMPOSE_FILE_3)
 	endif
-	override COMPOSE_FILE=$(COMPOSE_FILE_2)
+        # Use am-shib.dev.yml instead am-shib.yml
+        COMPOSE_FILE_4 := $(subst am-shib.yml,am-shib.dev.yml,$(COMPOSE_FILE_2))
+        override COMPOSE_FILE=$(COMPOSE_FILE_4)
 endif
 export COMPOSE_FILE
 

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -67,7 +67,7 @@ export COMPOSE_FILE
 VERSION ?= $(shell git describe --tags --always --dirty)
 export VERSION
 
-all: destroy build create-secrets up bootstrap list
+all: destroy build create-secrets up bootstrap restart-all-services list
 
 bootstrap create-secrets reset-processing-configs:
 	$(foreach DIR, $(COMPOSE_DIRS), $(MAKE) -C $(DIR) $@ ;)
@@ -177,6 +177,15 @@ destroy-volumes:
 
 list:
 	docker-compose ps
+
+restart-all-services:
+	# Restart all services and then restart again the gearmand and its
+	# dependent services 
+	docker-compose restart
+	docker-compose restart gearmand
+	docker-compose restart archivematica-mcp-client
+	docker-compose restart archivematica-mcp-server
+	docker-compose restart archivematica-dashboard
 
 up:
 	docker-compose up -d

--- a/compose/README.md
+++ b/compose/README.md
@@ -92,6 +92,7 @@ These service sets are defined by the following `docker-compose` configuration f
 
 1. [docker-compose.qa.yml](docker-compose.qa.yml)
 1. [docker-compose.dev.yml](docker-compose.dev.yml)
+1. [docker-compose.am-shib.dev.yml](docker-compose.am-shib.dev.yml)
 1. [docker-compose.mock-aws.qa.yml](docker-compose.mock-aws.qa.yml)
 1. [docker-compose.mock-aws.dev.yml](docker-compose.mock-aws.dev.yml)
 1. [docker-compose.am-shib.yml](docker-compose.am-shib.yml)
@@ -168,7 +169,7 @@ There is no Shibboleth integration in this usage. To enable Shibboleth, use this
 
 	make all ENV=dev SHIBBOLETH_CONFIG=archivematica
 
-This will include additional services defined in [docker-compose.am-shib.yml](docker-compose.am-shib.yml) in addition to those in [docker-compose.dev.yml](docker-compose.dev.yml).
+This will include additional services defined in [docker-compose.am-shib.dev.yml](docker-compose.am-shib.dev.yml) in addition to those in [docker-compose.dev.yml](docker-compose.dev.yml).
 
 By default this will include the local example Shibboleth IdP in [docker-compose.shib-local.yml](docker-compose.shib-local.yml) too. In future it may be possible to define a different Shibboleth IdP using the `SHIBBOLETH_IDP` environment variable (e.g. to use the UKAMF or UKAMF test IdPs). Alternatively, the `SHIBBOLETH_IDP_ENTITY_ID` and `SHIBBOLETH_IDP_METADATA_URL` environment variables may be used to override this. To use an alternative IdP and prevent the local IdP from being created, use `SHIBBOLETH_IDP=false`.
 

--- a/compose/am-shib/Makefile
+++ b/compose/am-shib/Makefile
@@ -6,7 +6,11 @@ BASE_DIR ?= ${CURDIR}
 
 VOL_BASE ?= $(BASE_DIR)/..
 
-DEFAULT_COMPOSE_FILE = $(shell realpath ../docker-compose.am-shib.yml)
+ifeq ("$(ENV)", "dev")
+        DEFAULT_COMPOSE_FILE := $(shell realpath ../docker-compose.am-shib.dev.yml)
+else
+        DEFAULT_COMPOSE_FILE := $(shell realpath ../docker-compose.am-shib.yml)
+endif
 
 COMPOSE_FILE ?= "${DEFAULT_COMPOSE_FILE}"
 

--- a/compose/dev/Makefile
+++ b/compose/dev/Makefile
@@ -18,9 +18,17 @@ export VERSION
 all: destroy bootstrap
 	docker-compose ps
 
-build:
+build: build-nextcloud-apps build-docker
+
+build-docker:
 	# Specify compose file explicitly, we don't want to build any other container sets
 	COMPOSE_FILE=$(DEFAULT_COMPOSE_FILE) docker-compose build
+
+build-nextcloud-apps:
+	# Make sure NextCloud apps are built
+	@cd $(BASE_DIR)/../../src/rdss-arkivum-nextcloud/ && \
+		make build-apps && cd $(BASE_DIR)
+
 
 bootstrap: build bootstrap-storage-service bootstrap-dashboard bootstrap-dashboard-frontend restart-mcp-services
 

--- a/compose/docker-compose.am-shib.dev.yml
+++ b/compose/docker-compose.am-shib.dev.yml
@@ -1,0 +1,110 @@
+---
+version: "2"
+
+#
+# Dev environment configuration for am-shib
+#
+
+services:
+
+  # Applies SSL as a proxy in front of the Shibboleth SP proxy
+  nginx-ssl:
+    image: "arkivum/nginx-ssl"
+    build:
+      context: "./am-shib/nginx-ssl/"
+    networks:
+      default:
+          aliases:
+            - "dashboard.archivematica.${DOMAIN_NAME}"
+            - "nextcloud.${DOMAIN_NAME}"
+            - "ss.archivematica.${DOMAIN_NAME}"
+      shibnet:
+          aliases:
+            - "dashboard.archivematica.${DOMAIN_NAME}"
+            - "nextcloud.${DOMAIN_NAME}"
+            - "ss.archivematica.${DOMAIN_NAME}"
+    ports:
+      - "${NGINX_EXTERNAL_IP}:${AM_EXTERNAL_PORT}:443"
+    environment:
+      AM_DASHBOARD_HOST: "dashboard.archivematica.${DOMAIN_NAME}"
+      AM_STORAGE_SERVICE_HOST: "ss.archivematica.${DOMAIN_NAME}"
+      AM_EXTERNAL_PORT:
+      NEXTCLOUD_HOST: "nextcloud.${DOMAIN_NAME}"
+      NEXTCLOUD_EXTERNAL_SSL_PORT:
+      NEXTCLOUD_PROXIED_HOST: "nextcloud"
+      SHIB_SP_HOST: "shib-sp-proxy"
+    volumes:
+      - "${VOL_BASE}/am-shib/build/secrets/:/secrets/:ro"
+    depends_on:
+      - "nextcloud"
+      - "shib-sp-proxy"
+
+  # Enforces Shibboleth authentication in front of our AM nginx proxy
+  shib-sp-proxy:
+    build:
+      context: "${VOL_BASE}/../src/rdss-archivematica-shib-sp-proxy/"
+    networks:
+      default:
+      shibnet:
+    environment:
+      # Target proxy (our nginx container)
+      TARGET_PROXY_HOST: "nginx"
+      # Archivematica
+      AM_DASHBOARD_HOST: "dashboard.archivematica.${DOMAIN_NAME}"
+      AM_DASHBOARD_SSL_CA_BUNDLE_FILE: "/secrets/sp-proxy/sp-ca-bundle.pem"
+      AM_DASHBOARD_SSL_CERT_FILE: "/secrets/sp-proxy/sp-am-dash-cert.pem"
+      AM_DASHBOARD_SSL_KEY_FILE: "/secrets/sp-proxy/sp-am-dash-key.pem"
+      AM_DASHBOARD_TARGET_PORT: "80"
+      AM_STORAGE_SERVICE_HOST: "ss.archivematica.${DOMAIN_NAME}"
+      AM_STORAGE_SERVICE_SSL_CA_BUNDLE_FILE: "/secrets/sp-proxy/sp-ca-bundle.pem"
+      AM_STORAGE_SERVICE_SSL_CERT_FILE: "/secrets/sp-proxy/sp-am-ss-cert.pem"
+      AM_STORAGE_SERVICE_SSL_KEY_FILE: "/secrets/sp-proxy/sp-am-ss-key.pem"
+      AM_STORAGE_SERVICE_TARGET_PORT: "8000"
+      AM_EXTERNAL_PORT:
+      # Shibboleth FastCGI SP config
+      SHIBBOLETH_IDP_ENTITY_ID: "https://idp.${DOMAIN_NAME}/idp/shibboleth"
+      SHIBBOLETH_IDP_METADATA_URL: "https://idp.${DOMAIN_NAME}:${IDP_EXTERNAL_PORT}/idp/shibboleth"
+      # Metadata config - set URL subst to same as IdP metadata URL for our local IDP
+      SHIBBOLETH_METADATA_SIGNING_CERT: "/etc/shibboleth/md-signing.crt"
+      SHIBBOLETH_METADATA_URL_SUBST: "https://idp.${DOMAIN_NAME}:${IDP_EXTERNAL_PORT}/idp/shibboleth"
+      # Error support contact
+      SHIBBOLETH_SUPPORT_EMAIL: "shibboleth-support@${DOMAIN_NAME}"
+    volumes:
+      - "${VOL_BASE}/am-shib/build/secrets/:/secrets/:ro"
+      - "${VOL_BASE}/shib-local/build/secrets/idp/idp.${DOMAIN_NAME}.crt:/etc/shibboleth/md-signing.crt:ro"
+    depends_on:
+      - "nginx"
+
+  archivematica-dashboard:
+    environment:
+      ARCHIVEMATICA_DASHBOARD_SHIBBOLETH_AUTHENTICATION: "True"
+
+  archivematica-storage-service:
+    environment:
+      SS_SHIBBOLETH_AUTHENTICATION: "True"
+
+  # Enforces Shibboleth for NextCloud
+  nextcloud:
+    networks:
+      default:
+      shibnet:
+    environment:
+      # Proxy settings
+      HTTP_PROTOCOL: "https"
+      NEXTCLOUD_HOST: "nextcloud.${DOMAIN_NAME}"
+      NEXTCLOUD_PORT: "${NEXTCLOUD_EXTERNAL_SSL_PORT}"
+      PROXY_HOST: "nginx-ssl"
+      # Shibboleth
+      SHIBBOLETH_AUTHENTICATION: "true"
+      SHIB_IDP_ENTITY_ID: "https://idp.${DOMAIN_NAME}/idp/shibboleth"
+      SHIB_IDP_CERT_FILE: "/etc/shibboleth/md-signing.crt"
+      SHIB_IDP_SSO_URL: "https://idp.${DOMAIN_NAME}:4443/idp/profile/SAML2/Redirect/SSO"
+      SHIB_SP_CERT_FILE: "/secrets/ssl-proxy/nextcloud-cert.pem"
+      SHIB_SP_KEY_FILE: "/secrets/ssl-proxy/nextcloud-key.pem"
+    volumes:
+      - "${VOL_BASE}/am-shib/build/secrets/:/secrets/:ro"
+      - "${VOL_BASE}/shib-local/build/secrets/idp/idp.${DOMAIN_NAME}.crt:/etc/shibboleth/md-signing.crt:ro"
+
+networks:
+  shibnet:
+    driver: "bridge"


### PR DESCRIPTION
This pull request fixes issues #218, #219 and #221:

* Adding a new `docker-compose.am-shib.dev.yml` file to use when deploying with Shibboleth and ENV=qa. (issue #218)
* Adding a new Makefile target to restart all containers at the end of the deploy (needed by Shibboleth) (issue #219)
* Adding the `build-nextcloud-apps` target to `dev/Makefile` (it is used by `qa/Makefile`) (issue #221)

