### PR TITLE
Disable adapter producer

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -196,7 +196,6 @@ After a successful build of the Shibboleth-enabled Archivematica services and Ne
 	rdss_nginx-ssl_1                                      /usr/local/bin/ep -v /etc/ ...   Up       0.0.0.0:443->443/tcp, 80/tcp
 	rdss_nginx_1                                          nginx -g daemon off;             Up       0.0.0.0:34057->80/tcp, 0.0.0.0:34056->8000/tcp
 	rdss_rdss-archivematica-channel-adapter-consumer_1    /go/bin/rdss-archivematica ...   Up       0.0.0.0:34061->6060/tcp
-	rdss_rdss-archivematica-channel-adapter-publisher_1   /go/bin/rdss-archivematica ...   Exit 1
 	rdss_rdss-archivematica-msgcreator_1                  /go/bin/rdss-archivematica ...   Up       8000/tcp
 	rdss_redis_1                                          docker-entrypoint.sh --sav ...   Up       6379/tcp
 	rdss_shib-sp-proxy_1                                  /usr/local/bin/run-app.sh        Up       80/tcp
@@ -269,6 +268,8 @@ Channel Adapter
 -----------------
 
 The RDSS Channel Adapter publisher and consumer require access to AWS services, namely DynamoDB, Kinesis and S3. If these are not available, for example on a local development or QA environment, then mock services will be used instead. However, if you do wish to use real AWS services, the following will be of use.
+
+The publisher is not being used at the moment since we're not producing messages yet.
 
 In addition, the names of the queues to use for a deployment must be specified. For local usage, the defaults are fine, but for real usage they should include the deployment id too.
 

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -52,13 +52,6 @@ services:
     volumes:
       - "${VOL_BASE}/../src/rdss-archivematica-channel-adapter:/go/src/github.com/JiscRDSS/rdss-archivematica-channel-adapter"
 
-  rdss-archivematica-channel-adapter-publisher:
-    build:
-      context: "../src/rdss-archivematica-channel-adapter"
-    entrypoint: "go run main.go publisher"
-    volumes:
-      - "${VOL_BASE}/../src/rdss-archivematica-channel-adapter:/go/src/github.com/JiscRDSS/rdss-archivematica-channel-adapter"
-
   rdss-archivematica-msgcreator:
     build:
       context: "../src/qa/rdss-archivematica-msgcreator"

--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -280,26 +280,6 @@ services:
     ports:
       - "6060" # See net/http/pprof
 
-  # TODO Change this to use AWS services for QA but still use mock for dev
-  rdss-archivematica-channel-adapter-publisher:
-    image: '${REGISTRY}rdss-archivematica-channel-adapter:${RDSS_CHANADAPTER_VERSION}'
-    command: "publisher"
-    environment:
-      RDSS_ARCHIVEMATICA_ADAPTER_LOGGING.LEVEL: "debug"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.MAIN: "${RDSS_ADAPTER_QUEUE_OUTPUT}"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.INVALID: "${RDSS_ADAPTER_QUEUE_INVALID}"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.QUEUES.ERROR: "${RDSS_ADAPTER_QUEUE_ERROR}"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.BACKEND: "kinesis"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.KINESIS.TLS: "${RDSS_ADAPTER_KINESIS_TLS}"
-      RDSS_ARCHIVEMATICA_ADAPTER_BROKER.KINESIS.ENDPOINT: "${RDSS_ADAPTER_KINESIS_ENDPOINT}"
-      AWS_REGION: "${RDSS_ADAPTER_KINESIS_AWS_REGION}"
-      AWS_ACCESS_KEY: "${RDSS_ADAPTER_KINESIS_AWS_ACCESS_KEY}"
-      AWS_SECRET_KEY: "${RDSS_ADAPTER_KINESIS_AWS_SECRET_KEY}"
-    links:
-      - "archivematica-dashboard"
-    ports:
-      - "6060" # See net/http/pprof
-
   # TODO Change this to use AWS service for QA but still use mock for dev
   rdss-archivematica-msgcreator:
     image: '${REGISTRY}rdss-archivematica-msgcreator:${RDSS_MSGCREATOR_VERSION}'


### PR DESCRIPTION
This commits removes the producer from the list of services being deployed.
This component is unused at the moment. We can introduce again when needed.

[RDSSARK-562](https://jiscdev.atlassian.net/browse/RDSSARK-562).