### PR TITLE
compose: configure new adapter transfer source

### DIFF
--- a/compose/docker-compose.qa.yml
+++ b/compose/docker-compose.qa.yml
@@ -252,6 +252,7 @@ services:
       RDSS_ARCHIVEMATICA_ADAPTER_AMCLIENT.URL: "http://archivematica-dashboard:8000"
       RDSS_ARCHIVEMATICA_ADAPTER_AMCLIENT.USER: "test"
       RDSS_ARCHIVEMATICA_ADAPTER_AMCLIENT.KEY: "test"
+      RDSS_ARCHIVEMATICA_ADAPTER_AMCLIENT.TRANSFER_DIR: "/home/adapter"
       RDSS_ARCHIVEMATICA_ADAPTER_S3.ENDPOINT: "${RDSS_ADAPTER_S3_ENDPOINT}"
       RDSS_ARCHIVEMATICA_ADAPTER_S3.FORCE_PATH_STYLE: "true"
       RDSS_ARCHIVEMATICA_ADAPTER_S3.INSECURE_SKIP_VERIFY: "true"
@@ -277,6 +278,7 @@ services:
       - "archivematica-dashboard"
     volumes:
       - "archivematica_pipeline_data:/var/archivematica/sharedDirectory:rw"
+      - "archivematica_storage_service_location_data:/home:rw"
     ports:
       - "6060" # See net/http/pprof
 


### PR DESCRIPTION
This PR:

*    Create a new transfer source location (`/home/adapter`) 
*    Add volume `archivematica_storage_service_location_data:/home:rw` to rdss-archivematica-channel-adapter-consumer so the adapter can write.
 *   Set `RDSS_ARCHIVEMATICA_ADAPTER_AMCLIENT.TRANSFER_DIR` to /home/adapter in the rdss-archivematica-channel-adapter-consumer service.

it fixes partially the #228 issue, but it doesn't set the new `TS` as default.